### PR TITLE
feat: login-mypage 統合 — マイページ/通知/AI分析/ウォレット/Infisical

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "7ceead12-f8c6-4385-a507-0a811f41af72",
+    "defaultEnvironment": "local",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,24 +201,50 @@ SMTP 経由でメールを送信するヘルパー。
 
 ---
 
-## 5. 環境変数
+## 5. シークレット管理 (Infisical)
+
+`.env` は廃止し、**Infisical** で集中管理する。`.infisical.json` (workspaceId / defaultEnvironment) はリポジトリにコミット、secret 本体は Infisical 側のみ。
+
+**environment スコープ**:
+- `local`  : Windows ローカル開発用 (default)
+- `mainnet`: 本番 VPS (mainnet)
+- `preview`: テストネット VPS (preview)
+
+**ローカル開発の起動コマンド**:
+
+```bash
+# Reflex 起動
+infisical run -- reflex run
+
+# 別 environment を使う場合
+infisical run --env=preview -- reflex run
+
+# notify_worker / ga_ai_worker 等の単発実行
+infisical run -- python notify_worker.py --event vote_sync
+```
+
+> 素の `reflex run` だと `os.getenv` が空を返して起動失敗する。必ず `infisical run --` でラップする。
+
+**VPS (systemd / cron) の運用**:
+
+VPS では Machine Identity (Service Token) で非対話認証する。詳細は `docs/realtime-notification-backend.md` 5-2。
+
+**管理対象 secret**:
 
 | 変数 | 説明 | デフォルト |
 |------|------|----------|
 | `KOIOS_NETWORK` | Koios ネットワーク（mainnet / preprod / preview） | `mainnet` |
+| `KOIOS_API_KEY` | Koios 認証キー（rate limit 緩和、任意） | - |
+| `OGMIOS_URL` | Ogmios WebSocket URL（リアルタイム通知用） | `ws://109.123.231.103:1337` |
 | `CARDANOISM_URL` | サイトの URL（通知メール内リンク等に使用） | `https://cardanoism.com` |
-| `LINE_CLIENT_ID` | LINE OAuth クライアント ID | - |
-| `LINE_CLIENT_SECRET` | LINE OAuth クライアントシークレット | - |
-| `LINE_REDIRECT_URI` | LINE OAuth コールバック URI | - |
-| `LINE_CHANNEL_ACCESS_TOKEN` | LINE Messaging API チャンネルアクセストークン | - |
-| `GOOGLE_CLIENT_ID` | Google OAuth クライアント ID | - |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth クライアントシークレット | - |
-| `GOOGLE_REDIRECT_URI` | Google OAuth コールバック URI | - |
-| `MAIL_SMTP_HOST` | SMTP サーバーホスト | - |
-| `MAIL_SMTP_PORT` | SMTP ポート（587=STARTTLS, 465=SSL） | `587` |
-| `MAIL_SMTP_USER` | SMTP ユーザー（送信元アドレス） | - |
-| `MAIL_SMTP_PASSWORD` | SMTP パスワード | - |
-| `MAIL_FROM_NAME` | 送信者表示名 | `Cardanoism` |
+| `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASS` / `DB_NAME` | MariaDB 接続情報 | - |
+| `LINE_CLIENT_ID` / `LINE_CLIENT_SECRET` / `LINE_REDIRECT_URI` | LINE OAuth | - |
+| `LINE_MESSAGING_TOKEN` | LINE Messaging API（通知用） | - |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_REDIRECT_URI` | Google OAuth | - |
+| `MAIL_SMTP_HOST` / `MAIL_SMTP_PORT` / `MAIL_SMTP_USER` / `MAIL_SMTP_PASSWORD` / `MAIL_FROM_NAME` | SMTP メール | - |
+| `TELEGRAM_BOT_TOKEN` | Telegram 通知 | - |
+| `GPT_API_KEY` | OpenAI API キー（GA AI 分析・投票理由翻訳） | - |
+| `OPENAI_MODEL` | OpenAI モデル名 | `gpt-4o-mini` |
 | `EPOCH_CHECK_WINDOW_MIN` | エポック切り替わりウィンドウ（分）。0=常に実行 | `0` |
 
 ---

--- a/cardanoism/backend/auth_state.py
+++ b/cardanoism/backend/auth_state.py
@@ -221,7 +221,10 @@ class AuthState(rx.State):
         if self._lang_manually_set or self.is_logged_in:
             return
         detected = "ja" if (browser_lang or "").lower().startswith("ja") else "en"
-        self.language = detected
+        # 同値ならスキップ — 代入すると t (@rx.var) が無効化されて全 i18n 依存
+        # コンポーネントが再レンダーされる (= 2 秒遅れの flicker の原因)
+        if self.language != detected:
+            self.language = detected
 
     def detect_browser_language(self):
         if self._lang_manually_set or self.is_logged_in:

--- a/cardanoism/backend/governance.py
+++ b/cardanoism/backend/governance.py
@@ -35,7 +35,8 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from dotenv import load_dotenv
-load_dotenv(PROJECT_ROOT / "cardanoism" / ".env", override=True)
+# シークレットは Infisical CLI で注入。.env は fallback (Infisical 値を上書きしない)。
+load_dotenv(PROJECT_ROOT / "cardanoism" / ".env", override=False)
 
 from cardanoism.backend.db_connect import get_db
 from cardanoism.backend.koios import _get

--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -308,6 +308,8 @@ UI_JA: dict[str, str] = {
     # 委任 (Phase 3): SPO カードのボタン + 委任ダイアログ
     "delegate_btn":                "委任する",
     "delegate_btn_currently":      "委任中",
+    "delegate_btn_coming_soon":    "委任機能 近日対応",
+    "wallet_coming_soon_note":     "ウォレット接続（所有確認）と委任機能は近日実装予定です",
     "delegate_modal_title":        "この SPO に委任しますか？",
     "delegate_modal_desc":         "下記の内容で委任 tx を作成し、ウォレットで署名・送信します。",
     "delegate_label_wallet":       "委任ウォレット",
@@ -812,6 +814,8 @@ UI_EN: dict[str, str] = {
     # Delegation (Phase 3): SPO card button + dialog
     "delegate_btn":                "Delegate",
     "delegate_btn_currently":      "Delegated",
+    "delegate_btn_coming_soon":    "Delegation coming soon",
+    "wallet_coming_soon_note":     "Wallet connection (ownership proof) and delegation are coming soon",
     "delegate_modal_title":        "Delegate to this SPO?",
     "delegate_modal_desc":         "Build a delegation transaction with the info below and sign / submit via your wallet.",
     "delegate_label_wallet":       "Delegating wallet",

--- a/cardanoism/components/navbar.py
+++ b/cardanoism/components/navbar.py
@@ -1,10 +1,6 @@
 import reflex as rx
 from cardanoism.backend.auth_state import AuthState
-from cardanoism.backend.wallet_state import WalletState
-from cardanoism.components.wallet_button import (
-    wallet_connector_mount,
-    wallet_status,
-)
+from cardanoism.components.wallet_button import wallet_connector_mount
 
 ACCENT = "#ffcf00"
 ACCENT_DARK = "#c7a300"
@@ -173,17 +169,6 @@ def navbar_icons() -> rx.Component:
             rx.hstack(
                 lang_toggle(),
                 divider,
-                # 接続中のみウォレットピルとそれに対応する仕切り線を表示
-                rx.cond(
-                    WalletState.connected,
-                    rx.hstack(
-                        wallet_status(),
-                        divider,
-                        spacing="3",
-                        align="center",
-                    ),
-                    rx.fragment(),
-                ),
                 auth_section(),
                 spacing="3",
                 align="center",

--- a/cardanoism/pages/mypage.py
+++ b/cardanoism/pages/mypage.py
@@ -10,11 +10,7 @@ import reflex as rx
 from cardanoism.templates import template
 from cardanoism.backend.auth_state import AuthState
 from cardanoism.components.login_modal import login_modal
-from cardanoism.components.wallet_button import (
-    wallet_connect_pill,
-    wallet_register_picker_menu,
-)
-from cardanoism.backend.wallet_state import WalletState
+from cardanoism.components.wallet_button import wallet_register_picker_menu
 from cardanoism.backend.auth_db import (
     POOL_NOTIFICATION_EVENT_TYPES,
     DELEGATOR_NOTIFICATION_EVENT_TYPES,
@@ -378,9 +374,6 @@ def profile_tab() -> rx.Component:
 # ============================================================
 
 def stake_address_card(addr: rx.Var[dict]) -> rx.Component:
-    is_active_wallet = (
-        WalletState.connected & (WalletState.reward_address == addr["address"])
-    )
     return rx.box(
         rx.hstack(
             rx.vstack(
@@ -411,8 +404,6 @@ def stake_address_card(addr: rx.Var[dict]) -> rx.Component:
                     align="start",
                     wrap="wrap",
                 ),
-                # ウォレット接続/検証状態 (このカードのアドレスに対して)
-                wallet_connect_pill(addr),
                 spacing="2",
                 align_items="start",
                 width="100%",
@@ -430,26 +421,9 @@ def stake_address_card(addr: rx.Var[dict]) -> rx.Component:
         ),
         padding="14px 16px",
         border_radius="10px",
-        border=rx.cond(
-            is_active_wallet,
-            "1px solid var(--green-7)",
-            f"1px solid {rx.color('gray', 4)}",
-        ),
-        background=rx.cond(
-            is_active_wallet,
-            rx.color_mode_cond(
-                "linear-gradient(135deg, var(--green-2), var(--green-3))",
-                "linear-gradient(135deg, rgba(34,197,94,0.14), rgba(34,197,94,0.05))",
-            ),
-            rx.color_mode_cond("white", "rgba(15,15,25,0.85)"),
-        ),
-        box_shadow=rx.cond(
-            is_active_wallet,
-            "0 0 0 3px rgba(34,197,94,0.10)",
-            "none",
-        ),
+        border=f"1px solid {rx.color('gray', 4)}",
+        background=rx.color_mode_cond("white", "rgba(15,15,25,0.85)"),
         width="100%",
-        style={"transition": "background 0.18s, border-color 0.18s, box-shadow 0.18s"},
     )
 
 
@@ -499,7 +473,15 @@ def stake_tab() -> rx.Component:
                                     "対応ウォレットを選ぶとアクティブアドレスが自動入力されます",
                                     size="1", color="var(--gray-10)",
                                 ),
-                                spacing="0", align_items="start",
+                                rx.hstack(
+                                    rx.icon("clock", size=11, color="var(--gray-9)"),
+                                    rx.text(
+                                        AuthState.t["wallet_coming_soon_note"],
+                                        size="1", color="var(--gray-9)",
+                                    ),
+                                    spacing="1", align="center",
+                                ),
+                                spacing="1", align_items="start",
                             ),
                             rx.spacer(),
                             wallet_register_picker_menu(

--- a/cardanoism/pages/staking_spo.py
+++ b/cardanoism/pages/staking_spo.py
@@ -15,13 +15,11 @@ import reflex as rx
 
 from cardanoism.templates import template
 from cardanoism.backend.auth_state import AuthState
-from cardanoism.backend.wallet_state import WalletState
 from cardanoism.backend.fiat_db import get_fiat_rate
 from cardanoism.backend.koios import get_totals
 from cardanoism.backend.pool_db import get_pools, count_pools
 from cardanoism.backend.price import format_ada, format_ada_short_ja, format_ada_short_en
 from cardanoism.components.staking_nav import staking_subnav
-from cardanoism.components.delegation_dialog import delegation_dialog
 
 # Cardano プロトコル定数（staking.py と同期）
 MAX_SUPPLY_LOVELACE = 45_000_000_000 * 1_000_000
@@ -496,77 +494,14 @@ def _pool_card(p) -> rx.Component:
         spacing="2", align="center",
     )
 
-    # 委任状態の判定:
-    #   - 接続中ウォレットの現在委任先 == このカードのプール: 「委任中」 (緑バッジ、クリック不可)
-    #   - 接続中: 「委任する」 (amber)
-    #   - 未接続: 「委任する」 (gray, disabled)
-    is_currently_delegated = (
-        WalletState.connected
-        & (WalletState.current_delegated_pool_id == p["pool_id"])
-    )
-    # 委任中の amber バッジ (リレー緑バッジと色で区別、サイズは揃える)
-    delegated_badge = rx.hstack(
-        rx.icon("circle-check", size=11, color="var(--amber-11)"),
+    # 委任機能は近日実装予定 — 委任アイコン (zap) + 文言で関連性を明示
+    delegate_button = rx.hstack(
+        rx.icon("zap", size=12, color="var(--gray-9)"),
         rx.text(
-            AuthState.t["delegate_btn_currently"],
-            size="1", weight="bold", color="var(--amber-12)",
-            style={"whiteSpace": "nowrap"},
-        ),
-        spacing="2",
-        align="center",
-        padding="4px 12px 4px 10px",
-        border_radius="999px",
-        background="var(--amber-3)",
-        border="1px solid var(--amber-8)",
-        cursor="default",
-        style={
-            "boxShadow": "0 1px 3px rgba(245,158,11,0.18)",
-            "display": "inline-flex",
-            "flexShrink": "0",
-        },
-    )
-    # 接続中: amber アウトライン (ゴースト風)。アクション要素なのでバッジより大きめ
-    delegate_active = rx.el.button(
-        rx.icon("zap", size=14, color="var(--amber-11)"),
-        rx.text(
-            AuthState.t["delegate_btn"],
-            color="var(--amber-12)",
-            style={
-                "fontSize": "13px",
-                "fontWeight": "700",
-                "lineHeight": "1.0",
-                "whiteSpace": "nowrap",
-            },
-        ),
-        on_click=WalletState.request_delegate_to_pool(p["pool_id"]),
-        cursor="pointer",
-        style={
-            "display": "inline-flex",
-            "alignItems": "center",
-            "gap": "6px",
-            "padding": "8px 16px",
-            "borderRadius": "999px",
-            "background": "transparent",
-            "border": "1.5px solid var(--amber-8)",
-            "transition": "background 0.15s ease, border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease",
-            "flexShrink": "0",
-            "boxShadow": "0 1px 2px rgba(0,0,0,0.04)",
-        },
-        _hover={
-            "background": "var(--amber-3)",
-            "border_color": "var(--amber-10)",
-            "transform": "translateY(-1px)",
-            "box_shadow": "0 4px 10px -2px rgba(245,158,11,0.25)",
-        },
-    )
-    # 未接続: 控えめグレー (active と同寸法でレイアウトずれを防ぐ)
-    delegate_disabled = rx.hstack(
-        rx.icon("zap", size=14, color="var(--gray-9)"),
-        rx.text(
-            AuthState.t["delegate_btn"],
+            AuthState.t["delegate_btn_coming_soon"],
             color="var(--gray-10)",
             style={
-                "fontSize": "13px",
+                "fontSize": "12px",
                 "fontWeight": "600",
                 "lineHeight": "1.0",
                 "whiteSpace": "nowrap",
@@ -574,26 +509,16 @@ def _pool_card(p) -> rx.Component:
         ),
         spacing="2",
         align="center",
-        padding="8px 16px",
+        padding="6px 14px",
         border_radius="999px",
         background="var(--gray-3)",
-        border="1.5px solid var(--gray-6)",
-        cursor="not-allowed",
+        border=f"1px dashed {rx.color('gray', 7)}",
+        cursor="default",
         style={
-            "opacity": "0.7",
+            "opacity": "0.85",
             "display": "inline-flex",
             "flexShrink": "0",
         },
-    )
-
-    delegate_button = rx.cond(
-        is_currently_delegated,
-        delegated_badge,
-        rx.cond(
-            WalletState.connected,
-            delegate_active,
-            delegate_disabled,
-        ),
     )
 
     metrics = rx.box(
@@ -657,7 +582,7 @@ def _pool_card(p) -> rx.Component:
         rx.fragment(),
     )
 
-    # ── ヘッダー: プール名 / ID / 概要 (明るめ背景) ─────────
+    # ── ヘッダー: プール名 / ID / 概要 (明るい白ベース) ─────
     header_section = rx.box(
         rx.vstack(
             rx.hstack(
@@ -673,11 +598,11 @@ def _pool_card(p) -> rx.Component:
             spacing="3", align_items="stretch", width="100%",
         ),
         padding="16px 18px 14px 18px",
-        background=rx.color_mode_cond("white", "rgba(255,255,255,0.04)"),
+        background=rx.color_mode_cond("white", "rgba(255,255,255,0.05)"),
         width="100%",
     )
 
-    # ── ボディ: 飽和率 + メトリクス (やや暗め背景で数値ゾーンを区別) ──
+    # ── ボディ: 飽和率 + メトリクス (淡いグレーで読みやすさ重視) ──
     body_section = rx.box(
         rx.vstack(
             saturation_row,
@@ -685,8 +610,8 @@ def _pool_card(p) -> rx.Component:
             spacing="3", align_items="stretch", width="100%",
         ),
         padding="14px 18px 16px 18px",
-        background=rx.color_mode_cond("var(--gray-3)", "rgba(0,0,0,0.18)"),
-        border_top=f"1px solid {rx.color('gray', 4)}",
+        background=rx.color_mode_cond("var(--gray-2)", "rgba(255,255,255,0.015)"),
+        border_top=f"1px solid {rx.color('gray', 5)}",
         width="100%",
     )
 
@@ -694,17 +619,23 @@ def _pool_card(p) -> rx.Component:
         header_section,
         body_section,
         border_radius="12px",
-        border=f"1px solid {rx.color('gray', 4)}",
+        border=f"1px solid {rx.color('gray', 5)}",
         overflow="hidden",  # 角の丸みで内側の背景を綺麗にクリップ
         width="100%",
+        # デフォルトでも軽いシャドウを付けてカードのエッジを浮かせる
+        box_shadow=rx.color_mode_cond(
+            "0 1px 3px rgba(15,23,42,0.06), 0 1px 2px rgba(15,23,42,0.04)",
+            "0 1px 3px rgba(0,0,0,0.35), 0 1px 2px rgba(0,0,0,0.20)",
+        ),
         _hover={
-            "border_color": rx.color("gray", 6),
+            "border_color": rx.color("amber", 8),
+            "transform": "translateY(-1px)",
             "box_shadow": rx.color_mode_cond(
-                "0 4px 14px -4px rgba(0,0,0,0.08)",
-                "0 4px 14px -4px rgba(0,0,0,0.40)",
+                "0 8px 22px -6px rgba(15,23,42,0.16), 0 4px 10px -4px rgba(245,158,11,0.18)",
+                "0 8px 22px -6px rgba(0,0,0,0.55), 0 4px 10px -4px rgba(245,158,11,0.22)",
             ),
         },
-        style={"transition": "border-color 0.15s, box-shadow 0.15s"},
+        style={"transition": "border-color 0.15s, box-shadow 0.18s, transform 0.18s"},
     )
 
 
@@ -867,8 +798,6 @@ def staking_spo_page() -> rx.Component:
         StakingSPOState.load,
         rx.box(
             rx.html(SPO_CSS),
-            # 委任確認モーダル (1 ページに 1 度だけマウント)
-            delegation_dialog(),
             rx.vstack(
                 _breadcrumb(),
                 staking_subnav("spo"),
@@ -883,7 +812,7 @@ def staking_spo_page() -> rx.Component:
                     StakingSPOState.pools,
                     rx.vstack(
                         rx.foreach(StakingSPOState.pools.to(list[dict[str, str]]), _pool_card),
-                        spacing="2", width="100%",
+                        spacing="3", width="100%",
                     ),
                     rx.callout(AuthState.t["staking_no_pools"], icon="info", color_scheme="gray"),
                 ),

--- a/docs/ga-ai-analysis-backend.md
+++ b/docs/ga-ai-analysis-backend.md
@@ -51,11 +51,13 @@ TreasuryWithdrawals の場合は機械計算による NCL 上限内チェック�
 
 ---
 
-## 2. 環境変数
+## 2. シークレット (Infisical)
+
+`.env` ではなく **Infisical** で管理する。`mainnet` / `preview` environment ごとに切替。詳細セットアップは `docs/realtime-notification-backend.md` 5-2 を参照。
 
 | 変数 | 説明 | デフォルト |
 |------|------|----------|
-| `GPT_API_KEY` | OpenAI API キー（`OPENAI_API_KEY` でも可） | - |
+| `GPT_API_KEY` | OpenAI API キー | - |
 | `KOIOS_NETWORK` | mainnet / preprod / preview | `mainnet` |
 | `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME` | MariaDB 接続情報 | - |
 
@@ -107,8 +109,7 @@ After=mysql.service network.target
 Type=simple
 User=cardanoism
 WorkingDirectory=/path/to/cardanoism
-EnvironmentFile=/path/to/cardanoism/.env
-ExecStart=/usr/bin/python /path/to/cardanoism/ga_ai_worker.py
+ExecStart=/usr/bin/bash -c '/usr/local/bin/infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- /path/to/cardanoism/.venv/bin/python /path/to/cardanoism/ga_ai_worker.py'
 Restart=always
 RestartSec=10
 

--- a/docs/koios-polling-backend.md
+++ b/docs/koios-polling-backend.md
@@ -84,7 +84,11 @@ done
 
 詳細は `cardanoism/backend/migrations/README.md`。
 
-### 3-3. 環境変数（`/opt/cardanoism/.env`）
+### 3-3. シークレット管理 (Infisical)
+
+`.env` ではなく **Infisical** で集中管理する。`mainnet` / `preview` environment ごとに secret を分離し、cron / systemd 起動時に CLI が `os.environ` に注入する。
+
+必要な secret 一覧:
 
 | 変数 | 必須 | 説明 |
 |------|:---:|------|
@@ -92,15 +96,15 @@ done
 | `CARDANOISM_URL` | ✅ | サイト URL（通知メッセージ内のリンク） |
 | `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASS` / `DB_NAME` | ✅ | MariaDB 接続情報 |
 | `KOIOS_API_KEY` | 任意 | Koios 認証キー（rate limit 緩和） |
-| `LINE_CHANNEL_ACCESS_TOKEN` | ⚠️ | LINE 通知 |
+| `LINE_MESSAGING_TOKEN` | ⚠️ | LINE 通知（Messaging API チャンネルアクセストークン） |
 | `MAIL_SMTP_HOST` / `MAIL_SMTP_PORT` / `MAIL_SMTP_USER` / `MAIL_SMTP_PASSWORD` | ⚠️ | メール通知 |
 | `MAIL_FROM_NAME` | 任意 | 送信者表示名（既定: `Cardanoism`） |
 | `TELEGRAM_BOT_TOKEN` | ⚠️ | Telegram 通知 |
-| `OPENAI_API_KEY` | 任意 | 投票理由翻訳（`vote_rationale_sync`） |
+| `GPT_API_KEY` | 任意 | OpenAI API キー（投票理由翻訳 `vote_rationale_sync` で使用） |
 
 ⚠️ は通知チャンネルを使う場合のみ必須。最低 1 つは設定。
 
-`notify_worker.py` 起動時に `cardanoism/.env` を `dotenv` で自動ロードする。systemd / cron 経由なら `EnvironmentFile=/opt/cardanoism/.env` 等で同等のロードを行う構成にしてもよい。
+VPS への CLI / Service Token セットアップは `docs/realtime-notification-backend.md` 5-2 と共通。cron では `infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- python notify_worker.py ...` の形でラップする。
 
 ---
 
@@ -113,42 +117,49 @@ done
 SHELL=/bin/bash
 WORKDIR=/opt/cardanoism
 PY=/opt/cardanoism/.venv/bin/python
+INF=/usr/local/bin/infisical
+TOKEN_FILE=/etc/cardanoism/infisical.token
+# Infisical の env スコープを切り替えるなら ENV=preview に変更
+ENV=mainnet
+RUN="$INF run --env=$ENV --token=$(cat $TOKEN_FILE) --"
 
 # ── 通知 ─────────────────────────────────────────────
 # プール系（saturation / pledge / reward）
-*/30 * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event pool         >> /var/log/cardanoism/notify.log 2>&1
+*/30 * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event pool         >> /var/log/cardanoism/notify.log 2>&1
 
 # DRep 系（status_change）
-*/30 * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event drep         >> /var/log/cardanoism/notify.log 2>&1
+*/30 * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event drep         >> /var/log/cardanoism/notify.log 2>&1
 
 # 委任リマインダー（pool / drep）
-0    * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event reminder     >> /var/log/cardanoism/notify.log 2>&1
+0    * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event reminder     >> /var/log/cardanoism/notify.log 2>&1
 
 # トレジャリー引き出し提案の enacted 検知
-0    * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event treasury     >> /var/log/cardanoism/notify.log 2>&1
+0    * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event treasury     >> /var/log/cardanoism/notify.log 2>&1
 
 # ── キャッシュ同期 ───────────────────────────────────
 # トレジャリー残高・履歴・NCL
-*/15 * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event treasury_sync >> /var/log/cardanoism/sync.log 2>&1
+*/15 * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event treasury_sync >> /var/log/cardanoism/sync.log 2>&1
 
 # 法定通貨レート（CoinGecko）
-*/10 * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event fiat_sync     >> /var/log/cardanoism/sync.log 2>&1
+*/10 * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event fiat_sync     >> /var/log/cardanoism/sync.log 2>&1
 
 # DRep 一覧・メタデータ
-0    */2 * * * cardanoism cd $WORKDIR && $PY notify_worker.py --event drep_sync    >> /var/log/cardanoism/sync.log 2>&1
+0    */2 * * * cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event drep_sync    >> /var/log/cardanoism/sync.log 2>&1
 
 # 投票履歴（GA 詳細用）
-*/30 * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event vote_sync     >> /var/log/cardanoism/sync.log 2>&1
+*/30 * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event vote_sync     >> /var/log/cardanoism/sync.log 2>&1
 
 # 投票集計
-*/30 * * * *  cardanoism cd $WORKDIR && $PY notify_worker.py --event summary_sync  >> /var/log/cardanoism/sync.log 2>&1
+*/30 * * * *  cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event summary_sync  >> /var/log/cardanoism/sync.log 2>&1
 
 # プロトコルパラメータ・CC メンバー
-0    */6 * * * cardanoism cd $WORKDIR && $PY notify_worker.py --event params_sync  >> /var/log/cardanoism/sync.log 2>&1
+0    */6 * * * cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event params_sync  >> /var/log/cardanoism/sync.log 2>&1
 
 # 投票理由の翻訳（OpenAI、無料枠の上限注意）
-0    */4 * * * cardanoism cd $WORKDIR && $PY notify_worker.py --event vote_rationale_sync >> /var/log/cardanoism/sync.log 2>&1
+0    */4 * * * cardanoism cd $WORKDIR && $RUN $PY notify_worker.py --event vote_rationale_sync >> /var/log/cardanoism/sync.log 2>&1
 ```
+
+cron は `$()` を直接展開できないため、`$RUN` 変数を組み立てる際に `$(cat ...)` を頭に出している点に注意。動かない場合は `--token-file=$TOKEN_FILE` 指定に切替えるか、wrapper script を用意する。
 
 ```bash
 sudo mkdir -p /var/log/cardanoism

--- a/docs/realtime-notification-backend.md
+++ b/docs/realtime-notification-backend.md
@@ -193,7 +193,11 @@ python3 -m venv .venv
 # `websockets>=12.0` が必要
 ```
 
-### 5-2. 環境変数（`/opt/cardanoism/.env`）
+### 5-2. シークレット管理 (Infisical)
+
+`.env` ではなく **Infisical** で集中管理する。本番 (mainnet) / テストネット (preview) を environment スコープで分離。
+
+必要な secret 一覧:
 
 | 変数 | 必須 | 説明 |
 |------|:---:|------|
@@ -201,21 +205,33 @@ python3 -m venv .venv
 | `KOIOS_NETWORK` | ✅ | `mainnet` / `preprod` / `preview`（Ogmios `/health` から自動検出可） |
 | `CARDANOISM_URL` | ✅ | サイト URL（通知メッセージ内のリンク用） |
 | `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASS` / `DB_NAME` | ✅ | MariaDB 接続情報 |
-| `LINE_CHANNEL_ACCESS_TOKEN` | ⚠️ | LINE 通知を使う場合 |
+| `LINE_MESSAGING_TOKEN` | ⚠️ | LINE 通知を使う場合（Messaging API チャンネルアクセストークン） |
 | `MAIL_SMTP_HOST` / `MAIL_SMTP_PORT` / `MAIL_SMTP_USER` / `MAIL_SMTP_PASSWORD` / `MAIL_FROM_NAME` | ⚠️ | メール通知を使う場合 |
 | `TELEGRAM_BOT_TOKEN` | ⚠️ | Telegram 通知を使う場合 |
 | `KOIOS_API_KEY` | 任意 | Koios の認証キー（DRep 投票時のタイトル補完・プール実績取得に使用） |
+
+VPS 側で Infisical CLI をインストールし、Machine Identity (Service Token) を発行して非対話認証する:
+
+```bash
+# CLI インストール
+curl -1sLf https://artifacts-cli.infisical.com/setup.deb.sh | sudo -E bash
+sudo apt install -y infisical
+
+# Service Token を保存 (Infisical Web UI → Project → Access Control → Machine Identities で発行)
+sudo install -m 0600 /dev/stdin /etc/cardanoism/infisical.token <<< "<TOKEN>"
+sudo chown cardanoism:cardanoism /etc/cardanoism/infisical.token
+```
 
 ### 5-3. 起動方法
 
 ```bash
 cd /opt/cardanoism
-.venv/bin/python ogmios_listener.py
-# または引数指定
-.venv/bin/python ogmios_listener.py --ogmios-url ws://127.0.0.1:1337
+infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+    .venv/bin/python ogmios_listener.py
 
-# 既存DBがありgenesisから再生したくない場合（推奨: 初回起動時）
-.venv/bin/python ogmios_listener.py --from-tip
+# 初回起動時のみ tip から再開
+infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+    .venv/bin/python ogmios_listener.py --from-tip
 ```
 
 `--from-tip` は **初回起動時のみ** に使う。tip からカーソルを設定し、ジェネシスからの再生をスキップする。2回目以降は `notification_check_state` の `ogmios_last_slot` から自動再開するため不要。
@@ -234,8 +250,8 @@ Requires=ogmios.service
 Type=simple
 User=cardanoism
 WorkingDirectory=/opt/cardanoism
-EnvironmentFile=/opt/cardanoism/.env
-ExecStart=/opt/cardanoism/.venv/bin/python ogmios_listener.py
+# Infisical Service Token をファイル経由で読み込む (Token 自体は環境変数として漏らさない)
+ExecStart=/usr/bin/bash -c '/usr/local/bin/infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- /opt/cardanoism/.venv/bin/python ogmios_listener.py'
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -244,6 +260,8 @@ StandardError=journal
 [Install]
 WantedBy=multi-user.target
 ```
+
+> preview テストネット用の listener を別途立てるときは `--env=preview` に変更し、別 unit (`ogmios-listener-preview.service`) として登録する。
 
 ```bash
 sudo systemctl daemon-reload
@@ -267,9 +285,9 @@ Ogmios `nextBlock` は `direction: "backward"` で網羅的にロールバック
 
 ## 7. ネットワーク切替（preprod / preview）
 
-`OGMIOS_URL` を切り替えれば `ogmios_listener.py` は `/health` の `network` フィールドから自動検出する。`KOIOS_NETWORK` 環境変数を明示する場合はそちらが優先される。
+Infisical で `mainnet` / `preview` environment を分けているので、systemd unit の `--env=` フラグだけ書き換えれば network 別の secret に切り替わる。`ogmios_listener.py` 自体は Ogmios `/health` の `network` フィールドから自動検出するため、コード側に変更は不要。
 
-cardano-node / Ogmios 側はネットワークごとに別の config 一式が必要。preprod の場合は `environments/preprod/config.json` を使い、別 systemd ユニットを立てる構成を推奨。
+cardano-node / Ogmios 側はネットワークごとに別の config 一式が必要。preprod の場合は `environments/preprod/config.json` を使い、別 systemd ユニット (`cardano-node-preprod.service`) を立てる構成を推奨。
 
 ---
 

--- a/ga_ai_worker.py
+++ b/ga_ai_worker.py
@@ -14,7 +14,7 @@ systemd 等で常駐させる想定。SIGINT / SIGTERM で graceful shutdown。
   python ga_ai_worker.py [--poll-interval 20] [--concurrency 3]
 
 依存:
-  ANTHROPIC_API_KEY ではなく GPT_API_KEY (or OPENAI_API_KEY) を使う。
+  ANTHROPIC_API_KEY ではなく GPT_API_KEY を使う。
 """
 from __future__ import annotations
 

--- a/notify_worker.py
+++ b/notify_worker.py
@@ -31,9 +31,10 @@ from datetime import datetime, timezone, timedelta
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# .env を明示的にロード（他モジュールの import より先に実行する必要がある）
+# シークレットは Infisical CLI (`infisical run -- python notify_worker.py ...`) で注入する。
+# .env は fallback としてのみ読み込み、Infisical 注入値を上書きしない。
 from dotenv import load_dotenv
-load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), "cardanoism", ".env"), override=True)
+load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), "cardanoism", ".env"), override=False)
 
 from cardanoism.backend.db_connect import get_db
 from cardanoism.backend.koios import (

--- a/rxconfig.py
+++ b/rxconfig.py
@@ -1,7 +1,9 @@
 import reflex as rx
 from dotenv import load_dotenv
 
-load_dotenv("cardanoism/.env", override=True)
+# シークレットは Infisical CLI (`infisical run -- ...`) で注入する。
+# .env が残っている場合は fallback としてのみ読み込む (Infisical 値を上書きしない)。
+load_dotenv("cardanoism/.env", override=False)
 
 config = rx.Config(
     app_name="cardanoism",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                           
                                                                                                                                                                                                                                       
  `login-mypage` ブランチに積まれた複数機能を `develop` に集約する。                                                                                                                                                                   
                                                                                                                                                                                                                                       
  ### マイページ + 認証
  - ソーシャルログイン (LINE / Google) — Authlib + サーバサイドセッション
  - マイページ `/mypage` (お気に入り / プロフィール / ステークアドレス / 通知管理)
  - ログインモーダル + ナビバーのアバター UI

  ### 通知バックエンド
  - リアルタイム: `ogmios_listener.py` (cardano-node + Ogmios)
  - ポーリング: `notify_worker.py` (Koios)
  - 常駐 AI ワーカー: `ga_ai_worker.py` (gpt-5.4-mini ファクト整理、A 方針)
  - 共通の dedup / log / channel merge 基盤

  ### ガバナンス
  - GA 詳細ページ刷新 (AI 分析セクション、委任先 DRep 投票カード)
  - NCL 残額チェック / Cardano 憲法ページ
  - 投票理由翻訳 (`vote_rationale_sync`)
  - トレジャリー残高 NCL 期間折れ線グラフ

  ### ステーキング UI 刷新
  - ライブブロック / 段別カラー / リレーバッジ
  - プール活動ヒートマップ
  - SPO 拡張メタ・mempool 表示
  - 委任先 SPO カード追加

  ### ウォレット接続
  - CIP-30 接続 + 所有確認 (Phase 1+2)
  - Phase 3 委任 tx 構築は保留 (`feature/phase3-pycardano` で再挑戦予定 — Reflex の WASM 制約)

  ### その他
  - TOP ページをランディング向けに刷新
  - Catalyst Fund タブ整理 (Fund 15 非表示)
  - シークレット管理を `.env` から **Infisical** に移行
  - ドキュメントの env 名を実コードに統一 (`LINE_MESSAGING_TOKEN` / `GPT_API_KEY`)