### PR TITLE
refactor(dashboard): GA セクションを未投票に集約 + 投票率バー + Ep 表記撤廃

### DIFF
--- a/cardanoism/backend/dashboard_state.py
+++ b/cardanoism/backend/dashboard_state.py
@@ -24,7 +24,7 @@ import reflex as rx
 
 from cardanoism.backend import auth_db
 from cardanoism.backend.auth_state import AuthState
-from cardanoism.backend.db_connect import get_db
+from cardanoism.backend.db_connect import get_db, _epoch_to_date, _attach_voting_summary
 from cardanoism.backend.pool_db import get_pool
 from cardanoism.backend.drep_db import get_drep
 from cardanoism.backend.vote_db import get_votes_by_drep
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 FAVORITES_PREVIEW_LIMIT = 5
 DREP_VOTES_PREVIEW_LIMIT = 5
 UNVOTED_GA_LIMIT = 5
-EXPIRING_GA_LIMIT = 5
 RECENT_REWARDS_EPOCHS = 5
 
 # Cardano mainnet エポック長 (= 5 days)
@@ -60,7 +59,6 @@ class DashboardState(rx.State):
     delegations_loading: bool = False
     pool_perf_loading: bool = False
     unvoted_gas_loading: bool = False
-    expiring_gas_loading: bool = False
     epoch_treasury_loading: bool = False
     notifications_loading: bool = False
 
@@ -107,10 +105,6 @@ class DashboardState(rx.State):
     # 委任先 DRep が未投票な active GA
     unvoted_gas_delegated: list[dict[str, str]] = []
 
-    # 締切が近い active GA (全件、絞り込みなし)
-    # entry: { proposal_id, title, title_ja, proposal_type, expiration, epochs_left }
-    expiring_gas: list[dict[str, str]] = []
-
     # エポック情報
     current_epoch_str: str = ""
     next_epoch_in_seconds: int = 0
@@ -133,7 +127,6 @@ class DashboardState(rx.State):
         self.delegations_loading = True
         self.pool_perf_loading = True
         self.unvoted_gas_loading = True
-        self.expiring_gas_loading = True
         self.epoch_treasury_loading = True
         self.notifications_loading = True
         self.load = True
@@ -148,7 +141,6 @@ class DashboardState(rx.State):
                 self.delegations_loading = False
                 self.pool_perf_loading = False
                 self.unvoted_gas_loading = False
-                self.expiring_gas_loading = False
                 self.epoch_treasury_loading = False
                 self.notifications_loading = False
                 return
@@ -179,7 +171,6 @@ class DashboardState(rx.State):
 
             self._load_governance_actions(auth.stake_addresses or [])
             self.unvoted_gas_loading = False
-            self.expiring_gas_loading = False
             yield
 
             # Koios `/totals` 1 回叩く (重め)
@@ -202,7 +193,6 @@ class DashboardState(rx.State):
             self.delegations_loading = False
             self.pool_perf_loading = False
             self.unvoted_gas_loading = False
-            self.expiring_gas_loading = False
             self.epoch_treasury_loading = False
             self.notifications_loading = False
 
@@ -224,7 +214,6 @@ class DashboardState(rx.State):
         self.rewards_missing_addresses = []
         self.unvoted_gas_self = []
         self.unvoted_gas_delegated = []
-        self.expiring_gas = []
         self.current_epoch_str = ""
         self.next_epoch_in_seconds = 0
         self.next_epoch_in_label = ""
@@ -503,13 +492,6 @@ class DashboardState(rx.State):
         except (TypeError, ValueError):
             cur_epoch = 0
 
-        # 締切が近い active GA (絞り込み無しの全件)
-        try:
-            self.expiring_gas = self._select_expiring_gas(cur_epoch)
-        except Exception as e:  # noqa: BLE001
-            logger.warning("_select_expiring_gas failed: %s", e)
-            self.expiring_gas = []
-
         # 自分が DRep として登録された stake_address (role="drep")
         own_drep_ids = [
             str(a.get("delegated_drep_id") or "")
@@ -541,45 +523,6 @@ class DashboardState(rx.State):
             self.unvoted_gas_delegated = []
 
     # ── 内部 SQL ───────────────────────────────────
-
-    @staticmethod
-    def _select_expiring_gas(current_epoch: int) -> list[dict[str, str]]:
-        """締切が近い active GA を返す。current_epoch=0 のときは全 active GA。"""
-        where = [
-            "ratified_epoch IS NULL",
-            "dropped_epoch IS NULL",
-            "expired_epoch IS NULL",
-            "enacted_epoch IS NULL",
-        ]
-        params: list = []
-        if current_epoch > 0:
-            where.append("expiration > ?")
-            params.append(current_epoch)
-        sql = (
-            "SELECT proposal_id, title, title_ja, proposal_type, expiration "
-            "FROM governance_actions "
-            f"WHERE {' AND '.join(where)} "
-            "ORDER BY expiration ASC "
-            f"LIMIT {EXPIRING_GA_LIMIT}"
-        )
-        with get_db() as (cursor, _):
-            cursor.execute(sql, params)
-            rows = [dict(r) for r in cursor.fetchall()]
-        out: list[dict[str, str]] = []
-        for r in rows:
-            exp = r.get("expiration")
-            epochs_left = ""
-            if exp is not None and current_epoch > 0:
-                epochs_left = str(max(0, int(exp) - current_epoch))
-            out.append({
-                "proposal_id":   str(r.get("proposal_id") or ""),
-                "title":         str(r.get("title") or ""),
-                "title_ja":      str(r.get("title_ja") or ""),
-                "proposal_type": str(r.get("proposal_type") or ""),
-                "expiration":    "" if exp is None else str(exp),
-                "epochs_left":   epochs_left,
-            })
-        return out
 
     @staticmethod
     def _select_active_gas_with_drep_vote(drep_id: str) -> list[dict[str, str]]:
@@ -649,8 +592,13 @@ class DashboardState(rx.State):
             where.append("g.expiration > ?")
             params.append(current_epoch)
         sql = (
-            "SELECT g.proposal_id, g.title, g.title_ja, g.proposal_type, g.expiration "
+            "SELECT g.proposal_id, g.title, g.title_ja, g.proposal_type, g.expiration, "
+            "g.block_time, g.proposed_epoch, "
+            "s.drep_yes_pct, s.drep_no_pct, "
+            "s.pool_yes_pct, s.pool_no_pct, "
+            "s.committee_yes_pct, s.committee_no_pct "
             "FROM governance_actions g "
+            "LEFT JOIN proposal_voting_summary s ON g.proposal_id = s.proposal_id "
             f"WHERE {' AND '.join(where)} "
             "ORDER BY g.expiration ASC "
             f"LIMIT {UNVOTED_GA_LIMIT}"
@@ -658,18 +606,26 @@ class DashboardState(rx.State):
         with get_db() as (cursor, _):
             cursor.execute(sql, params)
             rows = [dict(r) for r in cursor.fetchall()]
+
+        from cardanoism.backend.params_db import get_protocol_params
+        protocol_params = get_protocol_params() or {}
+
         out: list[dict[str, str]] = []
         for r in rows:
             exp = r.get("expiration")
-            epochs_left = ""
-            if exp is not None and current_epoch > 0:
-                epochs_left = str(max(0, int(exp) - current_epoch))
+            _attach_voting_summary(r, protocol_params)
             out.append({
-                "proposal_id":   str(r.get("proposal_id") or ""),
-                "title":         str(r.get("title") or ""),
-                "title_ja":      str(r.get("title_ja") or ""),
-                "proposal_type": str(r.get("proposal_type") or ""),
-                "expiration":    "" if exp is None else str(exp),
-                "epochs_left":   epochs_left,
+                "proposal_id":     str(r.get("proposal_id") or ""),
+                "title":           str(r.get("title") or ""),
+                "title_ja":        str(r.get("title_ja") or ""),
+                "proposal_type":   str(r.get("proposal_type") or ""),
+                "expiration":      "" if exp is None else str(exp),
+                "expiration_date": _epoch_to_date(
+                    exp, r.get("proposed_epoch"), r.get("block_time"),
+                ),
+                "drep_yes_pct":       str(r.get("drep_yes_pct") or "0"),
+                "drep_threshold_pct": str(r.get("drep_threshold_pct") or ""),
+                "drep_status":        str(r.get("drep_status") or ""),
+                "drep_applicable":    str(r.get("drep_applicable") or "no"),
             })
         return out

--- a/cardanoism/backend/db_connect.py
+++ b/cardanoism/backend/db_connect.py
@@ -1212,7 +1212,7 @@ _DISPLAY_TZ_LABEL = "JST"
 
 
 def _epoch_to_display(epoch, ref_epoch, ref_dt: datetime | None) -> str:
-    """エポック番号を 'Ep.NNN（YYYY/MM/DD JST）' 形式に変換する。
+    """エポック番号を 'Epoch NNN（YYYY/MM/DD JST）' 形式に変換する。
     ref_epoch/ref_dt（block_time, UTC）を基準に差分×エポック長で日付を算出し、
     JST に変換した上で TZ 略語を付与する。
     """
@@ -1225,10 +1225,29 @@ def _epoch_to_display(epoch, ref_epoch, ref_dt: datetime | None) -> str:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             dt_local = dt.astimezone(_DISPLAY_TZ)
-            return f"Ep.{n}（{dt_local.strftime('%Y/%m/%d')} {_DISPLAY_TZ_LABEL}）"
-        return f"Ep.{n}"
+            return f"Epoch {n}（{dt_local.strftime('%Y/%m/%d')} {_DISPLAY_TZ_LABEL}）"
+        return f"Epoch {n}"
     except (ValueError, TypeError):
         return str(epoch)
+
+
+def _epoch_to_date(epoch, ref_epoch, ref_dt: datetime | None) -> str:
+    """エポック番号を日付だけ 'YYYY/MM/DD JST' 形式に変換する。
+
+    Epoch 番号を出さず、ダッシュボードの未投票/締切 GA バッジのように
+    限られたスペースで「いつまで」だけ示したい場面で使う。
+    """
+    if epoch is None or ref_dt is None or ref_epoch is None:
+        return ""
+    try:
+        n = int(epoch)
+        dt = ref_dt + _EPOCH_DURATION * (n - int(ref_epoch))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        dt_local = dt.astimezone(_DISPLAY_TZ)
+        return f"{dt_local.strftime('%Y/%m/%d')} {_DISPLAY_TZ_LABEL}"
+    except (ValueError, TypeError):
+        return ""
 
 
 def _attach_voting_summary(row: Dict[str, Any], protocol_params: dict | None) -> None:

--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -388,9 +388,7 @@ UI_JA: dict[str, str] = {
     "dashboard_unvoted_self_label":       "あなた (DRep) が未投票",
     "dashboard_unvoted_delegated_label":  "委任先 DRep が未投票",
     "dashboard_unvoted_empty":            "現在未投票のアクティブ提案はありません",
-    "dashboard_expiring_title":           "締切が近いガバナンス提案",
-    "dashboard_expiring_empty":           "現在進行中の提案はありません",
-    "dashboard_ga_left_prefix":           "残り",
+    "dashboard_ga_deadline_label":        "期限:",
     "dashboard_login_required":           "ダッシュボードを表示するにはログインが必要です",
 
     # トレジャリーページ
@@ -971,9 +969,7 @@ UI_EN: dict[str, str] = {
     "dashboard_unvoted_self_label":       "You (DRep) haven't voted",
     "dashboard_unvoted_delegated_label":  "Your delegated DRep hasn't voted",
     "dashboard_unvoted_empty":            "No pending active proposals",
-    "dashboard_expiring_title":           "Expiring soon",
-    "dashboard_expiring_empty":           "No active proposals right now",
-    "dashboard_ga_left_prefix":           "in",
+    "dashboard_ga_deadline_label":        "Deadline:",
     "dashboard_login_required":           "Log in to view your dashboard",
 
     # Treasury page

--- a/cardanoism/backend/line_flex.py
+++ b/cardanoism/backend/line_flex.py
@@ -615,7 +615,7 @@ def pool_epoch_performance(
     if block_cnt is not None:
         rows.append(_row(t["pool_epoch_perf_blocks_label"], str(block_cnt), TEXT_PRIMARY))
     if apy is not None:
-        apy_label = f"{t['pool_epoch_perf_apy_label']}（Ep.{apy_epoch_no}）" if apy_epoch_no else t["pool_epoch_perf_apy_label"]
+        apy_label = f"{t['pool_epoch_perf_apy_label']}（Epoch {apy_epoch_no}）" if apy_epoch_no else t["pool_epoch_perf_apy_label"]
         rows.append(_row(apy_label, f"{apy:.2f}%", TEXT_APY))
 
     return _bubble(

--- a/cardanoism/backend/treasury_db.py
+++ b/cardanoism/backend/treasury_db.py
@@ -231,7 +231,7 @@ def build_treasury_chart_svg(history: list[dict]) -> str:
         x, _ = points_xy[i]
         parts.append(
             f'<text x="{x:.1f}" y="{H - pad_b + 18}" text-anchor="middle" '
-            f'font-size="10" fill="var(--gray-10)">Ep.{ep}</text>'
+            f'font-size="10" fill="var(--gray-10)">Epoch {ep}</text>'
         )
 
     parts.append("</svg>")

--- a/cardanoism/components/dashboard.py
+++ b/cardanoism/components/dashboard.py
@@ -628,9 +628,9 @@ def _epoch_treasury_section() -> rx.Component:
             spacing="1", align="center",
         ),
         rx.hstack(
+            rx.text("Epoch", size="2", color="var(--gray-10)"),
             rx.text(DashboardState.current_epoch_str, size="6", weight="bold", color="var(--gray-12)"),
-            rx.text("ep", size="2", color="var(--gray-10)"),
-            spacing="1", align="baseline",
+            spacing="2", align="baseline",
         ),
         rx.cond(
             DashboardState.next_epoch_in_label != "",
@@ -833,7 +833,7 @@ def _pool_performances_section() -> rx.Component:
 def _reward_recent_row(r: rx.Var) -> rx.Component:
     """popover 内: エポック別 1 行。"""
     return rx.hstack(
-        rx.text("ep", size="1", color="var(--gray-10)"),
+        rx.text("Epoch", size="1", color="var(--gray-10)"),
         rx.text(r["epoch_no"], size="1", weight="medium", color="var(--gray-12)"),
         rx.spacer(),
         rx.text(r["amount_ada"], size="2", weight="bold", color="var(--green-11)"),
@@ -951,34 +951,52 @@ def _rewards_popover(p: rx.Var) -> rx.Component:
 # ── 未投票 GA (Phase B) ────────────────────────
 
 def _ga_link_row(g: rx.Var) -> rx.Component:
+    """未投票 GA 1 件: 締切日付 + タイトル + DRep 投票率バー。"""
     title = rx.cond(
         AuthState.language == "ja",
         rx.cond(g["title_ja"] != "", g["title_ja"], g["title"]),
         g["title"],
     )
-    epochs_left_label = rx.cond(
-        g["epochs_left"] != "",
+    deadline_badge = rx.cond(
+        g["expiration_date"] != "",
         rx.badge(
-            AuthState.t["dashboard_ga_left_prefix"], " ", g["epochs_left"], " ep",
+            AuthState.t["dashboard_ga_deadline_label"],
+            g["expiration_date"],
             color_scheme="amber", variant="soft", size="1",
+            style={"flexShrink": "0", "whiteSpace": "nowrap"},
         ),
         rx.fragment(),
     )
-    return rx.link(
-        rx.hstack(
-            rx.icon("file-text", size=12, color="var(--gray-10)", flex_shrink="0"),
-            rx.text(
-                rx.cond(title != "", title, g["proposal_id"][:24] + "…"),
-                size="2", color="var(--gray-12)",
-                style={"overflow": "hidden", "textOverflow": "ellipsis", "whiteSpace": "nowrap"},
-                flex="1", min_width="0",
+    return rx.box(
+        rx.vstack(
+            rx.link(
+                rx.hstack(
+                    deadline_badge,
+                    rx.text(
+                        rx.cond(title != "", title, g["proposal_id"][:24] + "…"),
+                        size="2", weight="medium", color="var(--gray-12)",
+                        style={"overflow": "hidden", "textOverflow": "ellipsis", "whiteSpace": "nowrap"},
+                        flex="1", min_width="0",
+                    ),
+                    spacing="2", align="center", width="100%",
+                ),
+                href="/governance/" + g["proposal_id"],
+                underline="hover",
+                color="inherit",
+                width="100%",
             ),
-            epochs_left_label,
-            spacing="2", align="center", width="100%",
+            _vote_progress_bar(
+                "DRep",
+                g["drep_yes_pct"],
+                g["drep_threshold_pct"],
+                g["drep_applicable"],
+            ),
+            spacing="2", align="stretch", width="100%",
         ),
-        href="/governance/" + g["proposal_id"],
-        underline="hover",
-        color="inherit",
+        padding="10px 12px",
+        border_radius="8px",
+        background="var(--gray-2)",
+        border=f"1px solid {rx.color('gray', 4)}",
         width="100%",
     )
 
@@ -995,7 +1013,7 @@ def _unvoted_gas_section() -> rx.Component:
                 DashboardState.unvoted_gas_self.to(list[dict[str, str]]),
                 _ga_link_row,
             ),
-            spacing="1", align="stretch", width="100%",
+            spacing="2", align="stretch", width="100%",
         ),
         rx.fragment(),
     )
@@ -1010,7 +1028,7 @@ def _unvoted_gas_section() -> rx.Component:
                 DashboardState.unvoted_gas_delegated.to(list[dict[str, str]]),
                 _ga_link_row,
             ),
-            spacing="1", align="stretch", width="100%",
+            spacing="2", align="stretch", width="100%",
         ),
         rx.fragment(),
     )
@@ -1037,27 +1055,98 @@ def _unvoted_gas_section() -> rx.Component:
 
 # ── 締切が近い GA (Phase B) ────────────────────
 
-def _expiring_gas_section() -> rx.Component:
-    inner = rx.cond(
-        DashboardState.expiring_gas.length() > 0,
-        rx.vstack(
-            rx.foreach(
-                DashboardState.expiring_gas.to(list[dict[str, str]]),
-                _ga_link_row,
+def _vote_progress_bar(
+    label,
+    yes_pct: rx.Var,
+    threshold_pct: rx.Var,
+    applicable: rx.Var,
+) -> rx.Component:
+    """投票率の横バー (賛成率の塗りつぶし + 閾値マーカー)。
+
+    - 閾値の数字はマーカー直近 (バー上方) に配置することで視線移動を減らす
+    - applicable == "no" の場合はグレーアウト (該当しない voter group)
+    - threshold_pct が空文字なら閾値マーカー / 数字とも非表示
+    """
+    not_applicable = applicable == "no"
+    fill_color = rx.cond(not_applicable, "var(--gray-6)", "var(--blue-9)")
+    return rx.vstack(
+        # 上ラベル行: voter group 名 + 現在の賛成率
+        rx.hstack(
+            rx.text(
+                label,
+                size="1", weight="medium",
+                color=rx.cond(not_applicable, "var(--gray-9)", "var(--gray-11)"),
+                style={"minWidth": "40px"},
             ),
-            spacing="1", align="stretch", width="100%",
+            rx.spacer(),
+            rx.text(
+                yes_pct, "%",
+                size="1", weight="medium",
+                color=rx.cond(not_applicable, "var(--gray-9)", "var(--gray-12)"),
+            ),
+            spacing="1", align="baseline", width="100%",
         ),
-        rx.text(
-            AuthState.t["dashboard_expiring_empty"],
-            size="2", color="var(--gray-10)",
+        # バー本体 (上に閾値の数字を absolute で重ねる)
+        rx.box(
+            # 閾値ラベル (マーカー位置の真上に中央揃えで配置)
+            rx.cond(
+                threshold_pct != "",
+                rx.text(
+                    threshold_pct, "%",
+                    color="var(--gray-11)",
+                    position="absolute",
+                    top="-14px",
+                    left=threshold_pct + "%",
+                    style={
+                        "transform": "translateX(-50%)",
+                        "whiteSpace": "nowrap",
+                        "fontSize": "10px",
+                        "fontWeight": "500",
+                        "lineHeight": "1",
+                        "pointerEvents": "none",
+                    },
+                ),
+                rx.fragment(),
+            ),
+            # 背景バー
+            rx.box(
+                width="100%", height="6px",
+                background="var(--gray-3)",
+                border_radius="3px",
+            ),
+            # 賛成率の塗りつぶし
+            rx.box(
+                width=yes_pct + "%",
+                height="6px",
+                background=fill_color,
+                border_radius="3px",
+                position="absolute",
+                top="0", left="0",
+                style={"transition": "width 0.3s ease"},
+            ),
+            # 閾値マーカー (縦線)
+            rx.cond(
+                threshold_pct != "",
+                rx.box(
+                    width="2px", height="10px",
+                    background="var(--gray-12)",
+                    position="absolute",
+                    top="-2px",
+                    left=threshold_pct + "%",
+                    border_radius="1px",
+                ),
+                rx.fragment(),
+            ),
+            position="relative",
+            width="100%",
+            height="6px",
+            # 上部の閾値数字の分の余白 (絶対配置のため通常 flow に乗らない)
+            margin_top="14px",
         ),
+        spacing="1", align="stretch", width="100%",
     )
-    body = rx.cond(DashboardState.expiring_gas_loading, _section_spinner(), inner)
-    return _section_card(
-        AuthState.t["dashboard_expiring_title"],
-        "hourglass",
-        body,
-    )
+
+
 
 
 # ── ダッシュボード本体 ──────────────────────────
@@ -1079,7 +1168,6 @@ def dashboard() -> rx.Component:
             _pool_performances_section(),
             _drep_votes_section(),
             _unvoted_gas_section(),
-            _expiring_gas_section(),
             _favorites_section(),
             _notification_summary_section(),
             spacing="4",

--- a/cardanoism/pages/constitution.py
+++ b/cardanoism/pages/constitution.py
@@ -164,7 +164,7 @@ def _header() -> rx.Component:
                             size="2", color="var(--gray-10)",
                         ),
                         rx.text(
-                            "Ep." + ConstitutionState.constitution_enacted_epoch.to_string(),
+                            "Epoch " + ConstitutionState.constitution_enacted_epoch.to_string(),
                             size="2", weight="medium", color="var(--gray-12)",
                         ),
                         spacing="1", align="baseline",

--- a/cardanoism/pages/governance_treasury.py
+++ b/cardanoism/pages/governance_treasury.py
@@ -38,7 +38,7 @@ from cardanoism.components.login_modal import login_modal
 
 logger = logging.getLogger(__name__)
 
-# Cardano mainnet Shelley genesis (Ep.208 開始 = 2020-07-29 21:44:51 UTC)
+# Cardano mainnet Shelley genesis (Epoch 208 開始 = 2020-07-29 21:44:51 UTC)
 # NCL 提案は mainnet 固定なのでこの基準で算出する
 _SHELLEY_MAINNET_EPOCH = 208
 _SHELLEY_MAINNET_UNIX  = 1596059091

--- a/cardanoism/pages/mypage.py
+++ b/cardanoism/pages/mypage.py
@@ -64,7 +64,7 @@ def ga_favorite_card(fav: rx.Var[dict]) -> rx.Component:
                 ),
                 rx.hstack(
                     rx.badge(fav["proposal_type"], variant="soft", color_scheme="amber", size="1"),
-                    rx.text("Ep.", fav["proposed_epoch"].to(str), size="2", color="var(--gray-9)"),
+                    rx.text("Epoch ", fav["proposed_epoch"].to(str), size="2", color="var(--gray-9)"),
                     spacing="2",
                     wrap="wrap",
                 ),


### PR DESCRIPTION
未投票 GA と締切 GA セクションの統合:
  - 「締切が近いガバナンス提案」セクションを撤廃し、「未投票のガバナンス提案」 に集約。各行は [期限: YYYY/MM/DD JST] + タイトル + DRep 投票率バー
  - DashboardState の expiring_gas / expiring_gas_loading / _select_expiring_gas / EXPIRING_GA_LIMIT を削除
  - dashboard.py の _expiring_gas_row / _expiring_gas_section を削除し、 _ga_link_row に voting bar 付きの統合レイアウトへ置換
  - i18n から dashboard_expiring_title / dashboard_expiring_empty / dashboard_ga_left_prefix を削除

DRep 投票率バー:
  - 賛成率 (var(--blue-9)) の塗りつぶし + 閾値マーカー (縦線) を 1 行で表示
  - 閾値の数字をマーカー位置の真上に absolute 配置 (transform: translateX(-50%)) し、視線移動なしで「あといくらで批准」を把握できる
  - applicable=="no" の voter group はグレーアウト
  - 締切の砂時計アイコンを「期限:」テキストラベルに置換
  - 未投票 GA SQL に proposal_voting_summary を LEFT JOIN し、 _attach_voting_summary で閾値を計算

エポック表記の整理:
  - "Ep." / "ep" 表記を全て "Epoch" / "Epoch N" のフルワードに統一 (db_connect._epoch_to_display, constitution.py, mypage.py お気に入り, line_flex.py 報酬通知, treasury_db.py SVG, dashboard 各所)
  - 締切バッジは Epoch 番号を省いて日付のみ表示するため db_connect._epoch_to_date を新規追加 ("YYYY/MM/DD JST" 形式)