### PR TITLE
fix(notify): Telegram 連携用 ENUM 修正 + 通知チャンネル UI に Telegram 追加

### DIFF
--- a/cardanoism/backend/migrations/029_notification_channels_telegram.sql
+++ b/cardanoism/backend/migrations/029_notification_channels_telegram.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- 029_notification_channels_telegram.sql
+-- notification_channels.channel_type ENUM に 'telegram' を追加。
+--
+-- 001_users_auth.sql で初めから 'telegram' を含めて定義済みだが、
+-- 過去に 'line' / 'email' のみで作成された既存環境では ENUM が古いまま
+-- 残ってしまい、Telegram 連携時の UPSERT が
+--   "Data truncated for column 'channel_type' at row 1"
+-- で失敗する。この ALTER で確実に最新の ENUM 定義へ揃える。
+--
+-- 既に 'telegram' を含む環境では何も変わらない (冪等)。
+-- ============================================================
+
+ALTER TABLE notification_channels
+    MODIFY COLUMN channel_type ENUM('line', 'email', 'telegram') NOT NULL;

--- a/cardanoism/backend/migrations/README.md
+++ b/cardanoism/backend/migrations/README.md
@@ -36,6 +36,10 @@ Cardanoism の MariaDB スキーマ定義。
 | 023 | `023_pools_apy.sql` | pools.apy_history_7ep |
 | 024 | `024_stake_rewards.sql` | stake_rewards（ステークアドレスごとのエポック別報酬） |
 | 025 | `025_listener_event_slot.sql` | governance_actions / proposal_votes / dreps / pools / stake_addresses に last_event_slot を追加（Ogmios listener の rollback 対応） |
+| 026 | `026_stake_addresses_spo.sql` | stake_addresses.spo_pool_id (SPO 識別) |
+| 027 | `027_stake_rewards_type.sql` | stake_rewards.reward_type (member / leader / other 分離) + UNIQUE KEY 変更 |
+| 028 | `028_governance_actions_spo_target.sql` | governance_actions.spo_target (SPO 投票対象判定) |
+| 029 | `029_notification_channels_telegram.sql` | notification_channels.channel_type ENUM に 'telegram' を追加（既存 DB の古い ENUM 補完用、冪等） |
 
 ## 適用例
 

--- a/cardanoism/pages/mypage.py
+++ b/cardanoism/pages/mypage.py
@@ -986,12 +986,12 @@ def stake_notification_section(addr: rx.Var) -> rx.Component:
 
 
 def notification_channel_section() -> rx.Component:
-    """通知チャンネル選択セクション（メール・LINE連携済みの場合のみ表示）。"""
+    """通知チャンネル選択セクション（メール・LINE・Telegram いずれか連携済みの場合に表示）。"""
     has_email = AuthState.email_notify_channel != ""
     has_line = AuthState.line_notify_channel != ""
-    # どちらか1つでもある場合に表示
+    has_telegram = AuthState.telegram_chat_id != ""
     return rx.cond(
-        has_email | has_line,
+        has_email | has_line | has_telegram,
         rx.box(
             rx.vstack(
                 rx.hstack(
@@ -1032,7 +1032,7 @@ def notification_channel_section() -> rx.Component:
                         ),
                         rx.box(),
                     ),
-                    # 両方ある場合の区切り線
+                    # email + line の区切り線
                     rx.cond(
                         has_email & has_line,
                         rx.divider(),
@@ -1051,6 +1051,33 @@ def notification_channel_section() -> rx.Component:
                             rx.switch(
                                 checked=AuthState.line_notify_enabled,
                                 on_change=AuthState.set_line_notify_enabled,
+                                color_scheme="amber",
+                            ),
+                            justify="between",
+                            align="center",
+                            width="100%",
+                        ),
+                        rx.box(),
+                    ),
+                    # (line | email) + telegram の区切り線
+                    rx.cond(
+                        (has_email | has_line) & has_telegram,
+                        rx.divider(),
+                        rx.box(),
+                    ),
+                    # Telegram通知チャンネル
+                    rx.cond(
+                        has_telegram,
+                        rx.hstack(
+                            rx.hstack(
+                                rx.icon("send", size=16, color="#229ED9"),
+                                rx.text(AuthState.t["notification_channel_telegram"], size="3", weight="medium"),
+                                spacing="2",
+                                align="center",
+                            ),
+                            rx.switch(
+                                checked=AuthState.telegram_notify_enabled,
+                                on_change=AuthState.set_telegram_notify_enabled,
                                 color_scheme="amber",
                             ),
                             justify="between",


### PR DESCRIPTION
- migrations/029: notification_channels.channel_type ENUM に 'telegram' を 確実に含める ALTER (既存 DB が古いスキーマで作成されたケースの補完、冪等)
- mypage 通知設定タブの「通知チャンネル選択」カードに Telegram トグルを追加 (アイコン: send / Telegram ブランドカラー #229ED9 / 連携済み時のみ表示)