### PR TITLE
refactor(notify): Telegram テンプレを Cardanoism ブランド + 構造化レイアウトに統一

### DIFF
--- a/cardanoism/backend/koios.py
+++ b/cardanoism/backend/koios.py
@@ -893,6 +893,17 @@ def get_proposal_title(proposal_tx_hash: str, proposal_index: int = 0) -> str | 
     /proposal_list (GET) で全件取得し、proposal_tx_hash と index で照合して
     meta_json.body.title を返す。取得できない場合は proposal_type を返す。
     """
+    info = get_proposal_info(proposal_tx_hash, proposal_index)
+    if not info:
+        return None
+    return info.get("title") or info.get("proposal_type") or None
+
+
+def get_proposal_info(proposal_tx_hash: str, proposal_index: int = 0) -> dict | None:
+    """ガバナンスアクションの基本情報を返す。
+
+    戻り値: {"title": str, "proposal_id": str, "proposal_type": str} or None
+    """
     data = _get("/proposal_list")
     if not data or not isinstance(data, list):
         return None
@@ -901,8 +912,9 @@ def get_proposal_title(proposal_tx_hash: str, proposal_index: int = 0) -> str | 
         item_id = f"{item.get('proposal_tx_hash') or ''}#{item.get('proposal_index') or 0}"
         if item_id == target_id:
             body = (item.get("meta_json") or {}).get("body") or {}
-            title = _extract_str(body.get("title"))
-            if title:
-                return title
-            return _extract_str(item.get("proposal_type")) or None
+            return {
+                "title":         _extract_str(body.get("title")),
+                "proposal_id":   _extract_str(item.get("proposal_id")),
+                "proposal_type": _extract_str(item.get("proposal_type")),
+            }
     return None

--- a/cardanoism/backend/notify_templates/drep_delegation_reminder.py
+++ b/cardanoism/backend/notify_templates/drep_delegation_reminder.py
@@ -51,18 +51,29 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         return (
-            f"🗳️ <b>DRep委任リマインダー</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"DRep: {ctx['drep_name']}\n"
-            f"委任から {ctx['milestone']} 日が経過しました。DRepの活動を確認しましょう。"
+            "<b>🔔 Cardanoism — DRep委任リマインダー</b>\n"
+            "\n"
+            f"👤 {ctx['drep_name']}\n"
+            f"📅 委任から {ctx['milestone']} 日経過\n"
+            f"💼 {ctx['nickname']}で委任中\n"
+            "\n"
+            "委任先DRepの活動を確認しましょう。\n"
+            "\n"
+            f'→ <a href="{mypage_url}">マイページで委任先を確認</a>'
         )
     return (
-        f"🗳️ <b>DRep Delegation Reminder</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"DRep: {ctx['drep_name']}\n"
-        f"{ctx['milestone']} days since delegation. Please review your DRep's activity."
+        "<b>🔔 Cardanoism — DRep Delegation Reminder</b>\n"
+        "\n"
+        f"👤 {ctx['drep_name']}\n"
+        f"📅 {ctx['milestone']} days since delegation\n"
+        f"💼 Delegated from {ctx['nickname']}\n"
+        "\n"
+        "Please review your DRep's activity.\n"
+        "\n"
+        f'→ <a href="{mypage_url}">Check delegation on MyPage</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/drep_new_governance_action.py
+++ b/cardanoism/backend/notify_templates/drep_new_governance_action.py
@@ -7,14 +7,18 @@ from cardanoism.backend.notify_templates._dispatcher import register
 EVENT_TYPE = "drep_new_governance_action"
 
 
-def context(*, action_label: str, base_url: str) -> dict:
+def context(*, action_label: str, base_url: str,
+            proposal_id: str | None = None) -> dict:
     """action_label は表示用 (国庫引き出し / Treasury Withdrawals 等の lang 別文字列)。
     呼出側で _GA_TYPE_MAP_JA / _EN を使って解決済みの値を渡す前提。
     """
+    pid = proposal_id or ""
     return {
         "action_label": action_label,
         "base_url":     base_url,
         "gov_url":      f"{base_url}/governance",
+        "proposal_id":  pid,
+        "proposal_url": f"{base_url}/governance/{pid}" if pid else f"{base_url}/governance",
     }
 
 
@@ -49,14 +53,22 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 def render_telegram(ctx: dict, lang: str) -> str:
     if lang == "ja":
         return (
-            f"🗳️ <b>新ガバナンスアクション</b>\n"
-            f"種類: {ctx['action_label']}\n"
-            f"{ctx['gov_url']}"
+            "<b>🗳️ Cardanoism — 新ガバナンスアクション通知</b>\n"
+            "\n"
+            f"📋 提案タイプ: {ctx['action_label']}\n"
+            "\n"
+            "新しいガバナンスアクションが提出されました。\n"
+            "\n"
+            f'→ <a href="{ctx["proposal_url"]}">提案を確認する</a>'
         )
     return (
-        f"🗳️ <b>New Governance Action</b>\n"
-        f"Type: {ctx['action_label']}\n"
-        f"{ctx['gov_url']}"
+        "<b>🗳️ Cardanoism — New Governance Action</b>\n"
+        "\n"
+        f"📋 Proposal Type: {ctx['action_label']}\n"
+        "\n"
+        "A new governance action has been submitted.\n"
+        "\n"
+        f'→ <a href="{ctx["proposal_url"]}">View proposal</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/drep_status_change.py
+++ b/cardanoism/backend/notify_templates/drep_status_change.py
@@ -52,18 +52,25 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         return (
-            f"📋 <b>DRepステータス変更</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"DRep: {ctx['drep_name']}\n"
-            f"ステータス: {ctx['old_status']} → {ctx['new_status']}"
+            "<b>📋 Cardanoism — DRepステータス変更通知</b>\n"
+            "\n"
+            f"👤 {ctx['drep_name']}\n"
+            f"🔄 ステータス: {ctx['old_status']} → {ctx['new_status']}\n"
+            f"💼 {ctx['nickname']}で委任中\n"
+            "\n"
+            f'→ <a href="{mypage_url}">マイページで委任先を確認</a>'
         )
     return (
-        f"📋 <b>DRep Status Changed</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"DRep: {ctx['drep_name']}\n"
-        f"Status: {ctx['old_status']} → {ctx['new_status']}"
+        "<b>📋 Cardanoism — DRep Status Changed</b>\n"
+        "\n"
+        f"👤 {ctx['drep_name']}\n"
+        f"🔄 Status: {ctx['old_status']} → {ctx['new_status']}\n"
+        f"💼 Delegated from {ctx['nickname']}\n"
+        "\n"
+        f'→ <a href="{mypage_url}">Check delegation on MyPage</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/drep_vote.py
+++ b/cardanoism/backend/notify_templates/drep_vote.py
@@ -10,21 +10,53 @@ EVENT_TYPE = "drep_vote"
 _VOTE_LABEL_JA = {"yes": "賛成", "no": "反対", "abstain": "棄権"}
 _VOTE_LABEL_EN = {"yes": "Yes", "no": "No", "abstain": "Abstain"}
 
+_GA_TYPE_MAP_JA = {
+    "treasuryWithdrawals": "国庫引き出し",
+    "parameterChange":     "プロトコル変更",
+    "hardForkInitiation":  "ハードフォーク",
+    "noConfidence":        "不信任",
+    "updateCommittee":     "委員会変更",
+    "newConstitution":     "新憲法",
+    "information":         "情報提案",
+}
+_GA_TYPE_MAP_EN = {
+    "treasuryWithdrawals": "Treasury Withdrawals",
+    "parameterChange":     "Protocol Parameter Change",
+    "hardForkInitiation":  "Hard Fork Initiation",
+    "noConfidence":        "No Confidence",
+    "updateCommittee":     "Update Committee",
+    "newConstitution":     "New Constitution",
+    "information":         "Information",
+}
+
 
 def _label(vote: str, lang: str) -> str:
     v = (vote or "").lower()
     return (_VOTE_LABEL_JA if lang == "ja" else _VOTE_LABEL_EN).get(v, vote)
 
 
+def _action_label(action_type: str, lang: str) -> str:
+    if not action_type:
+        return ""
+    table = _GA_TYPE_MAP_JA if lang == "ja" else _GA_TYPE_MAP_EN
+    return table.get(action_type, action_type)
+
+
 def context(*, drep_name: str, vote: str, proposal_title: str | None,
-            nickname: str, base_url: str) -> dict:
+            nickname: str, base_url: str,
+            action_type: str | None = None,
+            proposal_id: str | None = None) -> dict:
+    pid = proposal_id or ""
     return {
         "drep_name":      drep_name,
         "vote":           (vote or "").lower(),
         "proposal_title": proposal_title or "",
+        "action_type":    action_type or "",
+        "proposal_id":    pid,
         "nickname":       nickname,
         "base_url":       base_url,
         "gov_url":        f"{base_url}/governance",
+        "proposal_url":   f"{base_url}/governance/{pid}" if pid else f"{base_url}/governance",
     }
 
 
@@ -69,24 +101,45 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 def render_telegram(ctx: dict, lang: str) -> str:
     label = _label(ctx["vote"], lang)
+    vote_icon = {"yes": "✅", "no": "❌", "abstain": "⚪"}.get(ctx["vote"], "🔘")
+    action_label = _action_label(ctx.get("action_type", ""), lang)
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
-        out = [
-            "🗳️ <b>DRep投票</b>",
-            f"ウォレット: {ctx['nickname']}",
-            f"DRep: {ctx['drep_name']}",
-            f"投票: {label}",
-        ]
+        out = ["<b>🗳️ Cardanoism — DRep投票通知</b>", ""]
         if ctx["proposal_title"]:
-            out.append(f"対象: {ctx['proposal_title']}")
+            out.append(f"📋 提案タイトル: {ctx['proposal_title']}")
+        if action_label:
+            out.append(f"📋 提案タイプ: {action_label}")
+        out.extend([
+            "",
+            f"👤 {ctx['drep_name']}",
+            f"{vote_icon} {label}",
+            f"💼 {ctx['nickname']}で委任中",
+            "",
+            "投票内容がご自身の意思と異なる場合は、",
+            "いつでも委任先 DRep を変更できます。",
+            "",
+            f'→ <a href="{ctx["proposal_url"]}">ガバナンス提案を確認する</a>',
+            f'→ <a href="{mypage_url}">マイページで委任先を変更</a>',
+        ])
     else:
-        out = [
-            "🗳️ <b>DRep Vote</b>",
-            f"Wallet: {ctx['nickname']}",
-            f"DRep: {ctx['drep_name']}",
-            f"Vote: {label}",
-        ]
+        out = ["<b>🗳️ Cardanoism — DRep Vote</b>", ""]
         if ctx["proposal_title"]:
-            out.append(f"Proposal: {ctx['proposal_title']}")
+            out.append(f"📋 Proposal Title: {ctx['proposal_title']}")
+        if action_label:
+            out.append(f"📋 Proposal Type: {action_label}")
+        out.extend([
+            "",
+            f"👤 {ctx['drep_name']}",
+            f"{vote_icon} {label}",
+            f"💼 Delegated from {ctx['nickname']}",
+            "",
+            "If the vote does not align with your intent,",
+            "you can change your delegated DRep at any time.",
+            "",
+            f'→ <a href="{ctx["proposal_url"]}">View proposal</a>',
+            f'→ <a href="{mypage_url}">Change delegation on MyPage</a>',
+        ])
     return "\n".join(out)
 
 

--- a/cardanoism/backend/notify_templates/epoch_start.py
+++ b/cardanoism/backend/notify_templates/epoch_start.py
@@ -38,12 +38,18 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 def render_telegram(ctx: dict, lang: str) -> str:
     if lang == "ja":
         return (
-            f"⏰ <b>新エポック開始</b>\n"
-            f"Epoch {ctx['epoch']} が始まりました。"
+            "<b>⏰ Cardanoism — 新エポック開始</b>\n"
+            "\n"
+            f"🆕 Epoch {ctx['epoch']} が始まりました\n"
+            "\n"
+            f'→ <a href="{ctx["base_url"]}">ダッシュボードを開く</a>'
         )
     return (
-        f"⏰ <b>New Epoch Started</b>\n"
-        f"Epoch {ctx['epoch']} has started."
+        "<b>⏰ Cardanoism — New Epoch Started</b>\n"
+        "\n"
+        f"🆕 Epoch {ctx['epoch']} has started\n"
+        "\n"
+        f'→ <a href="{ctx["base_url"]}">Open Dashboard</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/pool_delegation_reminder.py
+++ b/cardanoism/backend/notify_templates/pool_delegation_reminder.py
@@ -52,18 +52,29 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         return (
-            f"🔔 <b>委任リマインダー</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"プール: {ctx['pool_name']}\n"
-            f"委任から {ctx['milestone']} 日が経過しました。委任先を確認しましょう。"
+            "<b>🔔 Cardanoism — プール委任リマインダー</b>\n"
+            "\n"
+            f"🏊 {ctx['pool_name']}\n"
+            f"📅 委任から {ctx['milestone']} 日経過\n"
+            f"💼 {ctx['nickname']}で委任中\n"
+            "\n"
+            "委任先プールの状態を確認しましょう。\n"
+            "\n"
+            f'→ <a href="{mypage_url}">マイページで委任先を確認</a>'
         )
     return (
-        f"🔔 <b>Delegation Reminder</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"Pool: {ctx['pool_name']}\n"
-        f"{ctx['milestone']} days since delegation. Please review your pool."
+        "<b>🔔 Cardanoism — Pool Delegation Reminder</b>\n"
+        "\n"
+        f"🏊 {ctx['pool_name']}\n"
+        f"📅 {ctx['milestone']} days since delegation\n"
+        f"💼 Delegated from {ctx['nickname']}\n"
+        "\n"
+        "Please review the status of your pool.\n"
+        "\n"
+        f'→ <a href="{mypage_url}">Check delegation on MyPage</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/pool_epoch_performance.py
+++ b/cardanoism/backend/notify_templates/pool_epoch_performance.py
@@ -73,32 +73,43 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         lines = [
-            "📊 <b>プール実績通知</b>",
-            f"ウォレット: {ctx['nickname']}",
-            f"プール: {ctx['pool_name']}",
-            f"Epoch {ctx['prev_epoch']} 確定",
+            "<b>📊 Cardanoism — プール実績通知</b>",
+            "",
+            f"🏊 {ctx['pool_name']}",
+            f"📅 Epoch {ctx['prev_epoch']} 確定",
         ]
         if ctx["block_cnt"] is not None:
-            lines.append(f"ブロック生成数: {ctx['block_cnt']}")
+            lines.append(f"🧱 ブロック生成数: {ctx['block_cnt']}")
         if ctx["saturation_pct"] is not None:
-            lines.append(f"飽和度: {ctx['saturation_pct']:.1f}%")
+            lines.append(f"📈 飽和度: {ctx['saturation_pct']:.1f}%")
         if ctx["apy"] is not None:
-            lines.append(f"APY: {ctx['apy']:.2f}%")
+            lines.append(f"💹 APY: {ctx['apy']:.2f}%")
+        lines += [
+            f"💼 {ctx['nickname']}で委任中",
+            "",
+            f'→ <a href="{mypage_url}">マイページで実績を確認</a>',
+        ]
     else:
         lines = [
-            "📊 <b>Pool Performance</b>",
-            f"Wallet: {ctx['nickname']}",
-            f"Pool: {ctx['pool_name']}",
-            f"Epoch {ctx['prev_epoch']} confirmed",
+            "<b>📊 Cardanoism — Pool Performance</b>",
+            "",
+            f"🏊 {ctx['pool_name']}",
+            f"📅 Epoch {ctx['prev_epoch']} confirmed",
         ]
         if ctx["block_cnt"] is not None:
-            lines.append(f"Blocks: {ctx['block_cnt']}")
+            lines.append(f"🧱 Blocks: {ctx['block_cnt']}")
         if ctx["saturation_pct"] is not None:
-            lines.append(f"Saturation: {ctx['saturation_pct']:.1f}%")
+            lines.append(f"📈 Saturation: {ctx['saturation_pct']:.1f}%")
         if ctx["apy"] is not None:
-            lines.append(f"APY: {ctx['apy']:.2f}%")
+            lines.append(f"💹 APY: {ctx['apy']:.2f}%")
+        lines += [
+            f"💼 Delegated from {ctx['nickname']}",
+            "",
+            f'→ <a href="{mypage_url}">View performance on MyPage</a>',
+        ]
     return "\n".join(lines)
 
 

--- a/cardanoism/backend/notify_templates/pool_fee_change.py
+++ b/cardanoism/backend/notify_templates/pool_fee_change.py
@@ -78,32 +78,41 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
-    head_ja = "💱 <b>プール手数料変更</b>"
-    head_en = "💱 <b>Pool Fee Changed</b>"
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
-        lines = [head_ja, f"ウォレット: {ctx['nickname']}", f"プール: {ctx['pool_name']}"]
+        lines = ["<b>💱 Cardanoism — プール手数料変更通知</b>", "", f"🏊 {ctx['pool_name']}"]
         if ctx["fee_changed"]:
             lines += [
-                f"変動: {ctx['old_margin_pct']:.2f}% → {ctx['new_margin_pct']:.2f}%",
-                f"固定: {ctx['old_fixed_ada']:.0f} ADA → {ctx['new_fixed_ada']:.0f} ADA",
+                f"📊 変動手数料: {ctx['old_margin_pct']:.2f}% → {ctx['new_margin_pct']:.2f}%",
+                f"💰 固定手数料: {ctx['old_fixed_ada']:,.0f} ADA → {ctx['new_fixed_ada']:,.0f} ADA",
             ]
         if ctx["pledge_changed"]:
             if ctx["old_pledge_ada"] is not None:
-                lines.append(f"誓約: {ctx['old_pledge_ada']:.0f} ADA → {ctx['new_pledge_ada']:.0f} ADA")
+                lines.append(f"🔒 誓約: {ctx['old_pledge_ada']:,.0f} ADA → {ctx['new_pledge_ada']:,.0f} ADA")
             else:
-                lines.append(f"誓約: {ctx['new_pledge_ada']:.0f} ADA")
+                lines.append(f"🔒 誓約: {ctx['new_pledge_ada']:,.0f} ADA")
+        lines += [
+            f"💼 {ctx['nickname']}で委任中",
+            "",
+            f'→ <a href="{mypage_url}">マイページで委任先を確認</a>',
+        ]
     else:
-        lines = [head_en, f"Wallet: {ctx['nickname']}", f"Pool: {ctx['pool_name']}"]
+        lines = ["<b>💱 Cardanoism — Pool Fee Changed</b>", "", f"🏊 {ctx['pool_name']}"]
         if ctx["fee_changed"]:
             lines += [
-                f"Margin: {ctx['old_margin_pct']:.2f}% → {ctx['new_margin_pct']:.2f}%",
-                f"Fixed cost: {ctx['old_fixed_ada']:.0f} ADA → {ctx['new_fixed_ada']:.0f} ADA",
+                f"📊 Margin: {ctx['old_margin_pct']:.2f}% → {ctx['new_margin_pct']:.2f}%",
+                f"💰 Fixed cost: {ctx['old_fixed_ada']:,.0f} ADA → {ctx['new_fixed_ada']:,.0f} ADA",
             ]
         if ctx["pledge_changed"]:
             if ctx["old_pledge_ada"] is not None:
-                lines.append(f"Pledge: {ctx['old_pledge_ada']:.0f} ADA → {ctx['new_pledge_ada']:.0f} ADA")
+                lines.append(f"🔒 Pledge: {ctx['old_pledge_ada']:,.0f} ADA → {ctx['new_pledge_ada']:,.0f} ADA")
             else:
-                lines.append(f"Pledge: {ctx['new_pledge_ada']:.0f} ADA")
+                lines.append(f"🔒 Pledge: {ctx['new_pledge_ada']:,.0f} ADA")
+        lines += [
+            f"💼 Delegated from {ctx['nickname']}",
+            "",
+            f'→ <a href="{mypage_url}">Check delegation on MyPage</a>',
+        ]
     return "\n".join(lines)
 
 

--- a/cardanoism/backend/notify_templates/pool_pledge_shortage.py
+++ b/cardanoism/backend/notify_templates/pool_pledge_shortage.py
@@ -55,18 +55,31 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         return (
-            f"⚠️ <b>誓約不足アラート</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"プール: {ctx['pool_name']}\n"
-            f"誓約: {ctx['pledged_ada']:,.0f} ADA / 実績: {ctx['live_ada']:,.0f} ADA"
+            "<b>⚠️ Cardanoism — 誓約不足通知</b>\n"
+            "\n"
+            f"🏊 {ctx['pool_name']}\n"
+            f"🔒 誓約: {ctx['pledged_ada']:,.0f} ADA\n"
+            f"📊 実績: {ctx['live_ada']:,.0f} ADA\n"
+            f"💼 {ctx['nickname']}で委任中\n"
+            "\n"
+            "誓約不足のプールは報酬が減少する場合があります。\n"
+            "\n"
+            f'→ <a href="{mypage_url}">マイページで委任先を確認</a>'
         )
     return (
-        f"⚠️ <b>Pledge Shortage Alert</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"Pool: {ctx['pool_name']}\n"
-        f"Pledge: {ctx['pledged_ada']:,.0f} ADA / Live: {ctx['live_ada']:,.0f} ADA"
+        "<b>⚠️ Cardanoism — Pledge Shortage Alert</b>\n"
+        "\n"
+        f"🏊 {ctx['pool_name']}\n"
+        f"🔒 Pledge: {ctx['pledged_ada']:,.0f} ADA\n"
+        f"📊 Live: {ctx['live_ada']:,.0f} ADA\n"
+        f"💼 Delegated from {ctx['nickname']}\n"
+        "\n"
+        "Pools with insufficient pledge may have reduced rewards.\n"
+        "\n"
+        f'→ <a href="{mypage_url}">Check delegation on MyPage</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/pool_retire.py
+++ b/cardanoism/backend/notify_templates/pool_retire.py
@@ -50,18 +50,25 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         return (
-            f"⚠️ <b>プールリタイア通知</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"プール: {ctx['pool_name']}\n"
-            f"リタイア予定: Epoch {ctx['retiring_epoch']}"
+            "<b>⚠️ Cardanoism — プールリタイア通知</b>\n"
+            "\n"
+            f"🏊 {ctx['pool_name']}\n"
+            f"📅 リタイア予定: Epoch {ctx['retiring_epoch']}\n"
+            f"💼 {ctx['nickname']}で委任中\n"
+            "\n"
+            f'→ <a href="{mypage_url}">マイページで委任先を変更</a>'
         )
     return (
-        f"⚠️ <b>Pool Retirement</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"Pool: {ctx['pool_name']}\n"
-        f"Retiring at Epoch {ctx['retiring_epoch']}"
+        "<b>⚠️ Cardanoism — Pool Retirement</b>\n"
+        "\n"
+        f"🏊 {ctx['pool_name']}\n"
+        f"📅 Retiring at Epoch {ctx['retiring_epoch']}\n"
+        f"💼 Delegated from {ctx['nickname']}\n"
+        "\n"
+        f'→ <a href="{mypage_url}">Change delegation on MyPage</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/pool_reward_received.py
+++ b/cardanoism/backend/notify_templates/pool_reward_received.py
@@ -18,6 +18,7 @@ def context(
     nickname: str,
     is_leader: bool,
     base_url: str,
+    pool_name: str | None = None,
 ) -> dict:
     return {
         "reward_epoch": int(reward_epoch),
@@ -26,6 +27,7 @@ def context(
         "nickname":     nickname,
         "is_leader":    bool(is_leader),
         "base_url":     base_url,
+        "pool_name":    pool_name or "",
     }
 
 
@@ -79,29 +81,55 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
+    pool_name = ctx.get("pool_name") or ""
     if ctx["is_leader"]:
         if lang == "ja":
-            return (
-                f"👑 <b>SPO 報酬 (Leader) 入金</b>\n"
-                f"ウォレット: {ctx['nickname']}\n"
-                f"Epoch {ctx['reward_epoch']} SPO 報酬: {ctx['primary_ada']:.6f} ADA"
-            )
-        return (
-            f"👑 <b>SPO Leader Reward Received</b>\n"
-            f"Wallet: {ctx['nickname']}\n"
-            f"Epoch {ctx['reward_epoch']} SPO reward: {ctx['primary_ada']:.6f} ADA"
-        )
+            lines = ["<b>👑 Cardanoism — SPO 報酬入金通知</b>", ""]
+            if pool_name:
+                lines.append(f"🏊 {pool_name}")
+            lines += [
+                f"📅 Epoch {ctx['reward_epoch']}",
+                f"💰 Leader 報酬: {ctx['primary_ada']:.6f} ADA",
+                f"💼 {ctx['nickname']}で運用中",
+                "",
+                f'→ <a href="{mypage_url}">マイページで報酬履歴を確認</a>',
+            ]
+        else:
+            lines = ["<b>👑 Cardanoism — SPO Leader Reward Received</b>", ""]
+            if pool_name:
+                lines.append(f"🏊 {pool_name}")
+            lines += [
+                f"📅 Epoch {ctx['reward_epoch']}",
+                f"💰 Leader reward: {ctx['primary_ada']:.6f} ADA",
+                f"💼 Operated by {ctx['nickname']}",
+                "",
+                f'→ <a href="{mypage_url}">View reward history on MyPage</a>',
+            ]
+        return "\n".join(lines)
     if lang == "ja":
-        return (
-            f"💰 <b>ステーキング報酬入金</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"Epoch {ctx['reward_epoch']} 報酬: {ctx['primary_ada']:.6f} ADA"
-        )
-    return (
-        f"💰 <b>Staking Reward Received</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"Epoch {ctx['reward_epoch']} reward: {ctx['primary_ada']:.6f} ADA"
-    )
+        lines = ["<b>💰 Cardanoism — ステーキング報酬入金通知</b>", ""]
+        if pool_name:
+            lines.append(f"🏊 {pool_name}")
+        lines += [
+            f"📅 Epoch {ctx['reward_epoch']}",
+            f"💰 報酬: {ctx['primary_ada']:.6f} ADA",
+            f"💼 {ctx['nickname']}で委任中",
+            "",
+            f'→ <a href="{mypage_url}">マイページで報酬履歴を確認</a>',
+        ]
+    else:
+        lines = ["<b>💰 Cardanoism — Staking Reward Received</b>", ""]
+        if pool_name:
+            lines.append(f"🏊 {pool_name}")
+        lines += [
+            f"📅 Epoch {ctx['reward_epoch']}",
+            f"💰 Reward: {ctx['primary_ada']:.6f} ADA",
+            f"💼 Delegated from {ctx['nickname']}",
+            "",
+            f'→ <a href="{mypage_url}">View reward history on MyPage</a>',
+        ]
+    return "\n".join(lines)
 
 
 register(EVENT_TYPE, __import__(__name__, fromlist=["_"]))

--- a/cardanoism/backend/notify_templates/pool_saturation.py
+++ b/cardanoism/backend/notify_templates/pool_saturation.py
@@ -52,20 +52,29 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 
 
 def render_telegram(ctx: dict, lang: str) -> str:
+    mypage_url = f"{ctx['base_url']}/mypage?tab=stake"
     if lang == "ja":
         return (
-            f"⚠️ <b>委任先プール飽和アラート</b>\n"
-            f"ウォレット: {ctx['nickname']}\n"
-            f"プール: {ctx['pool_name']}\n"
-            f"飽和度: {ctx['sat_pct']:.1f}%\n"
-            f"委任先の変更をご検討ください。"
+            "<b>⚠️ Cardanoism — プール飽和通知</b>\n"
+            "\n"
+            f"🏊 {ctx['pool_name']}\n"
+            f"📈 飽和度: {ctx['sat_pct']:.1f}%\n"
+            f"💼 {ctx['nickname']}で委任中\n"
+            "\n"
+            "委任先の変更をご検討ください。\n"
+            "\n"
+            f'→ <a href="{mypage_url}">マイページで委任先を変更</a>'
         )
     return (
-        f"⚠️ <b>Pool Saturation Alert</b>\n"
-        f"Wallet: {ctx['nickname']}\n"
-        f"Pool: {ctx['pool_name']}\n"
-        f"Saturation: {ctx['sat_pct']:.1f}%\n"
-        f"Please consider changing your delegation."
+        "<b>⚠️ Cardanoism — Pool Saturation Alert</b>\n"
+        "\n"
+        f"🏊 {ctx['pool_name']}\n"
+        f"📈 Saturation: {ctx['sat_pct']:.1f}%\n"
+        f"💼 Delegated from {ctx['nickname']}\n"
+        "\n"
+        "Please consider changing your delegation.\n"
+        "\n"
+        f'→ <a href="{mypage_url}">Change delegation on MyPage</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/spo_pending_vote.py
+++ b/cardanoism/backend/notify_templates/spo_pending_vote.py
@@ -7,11 +7,15 @@ from cardanoism.backend.notify_templates._dispatcher import register
 EVENT_TYPE = "spo_pending_vote"
 
 
-def context(*, action_label: str, base_url: str) -> dict:
+def context(*, action_label: str, base_url: str,
+            proposal_id: str | None = None) -> dict:
+    pid = proposal_id or ""
     return {
         "action_label": action_label,
         "base_url":     base_url,
         "gov_url":      f"{base_url}/governance",
+        "proposal_id":  pid,
+        "proposal_url": f"{base_url}/governance/{pid}" if pid else f"{base_url}/governance",
     }
 
 
@@ -46,16 +50,24 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 def render_telegram(ctx: dict, lang: str) -> str:
     if lang == "ja":
         return (
-            f"👑 <b>SPO 投票対象 GA</b>\n"
-            f"種類: {ctx['action_label']}\n"
-            f"プールに代わって投票を検討してください。\n"
-            f"{ctx['gov_url']}"
+            "<b>👑 Cardanoism — SPO 投票対象 GA 通知</b>\n"
+            "\n"
+            f"📋 提案タイプ: {ctx['action_label']}\n"
+            "\n"
+            "SPO が投票可能な新しいガバナンスアクションが提出されました。\n"
+            "プールに代わって投票を検討してください。\n"
+            "\n"
+            f'→ <a href="{ctx["proposal_url"]}">提案を確認する</a>'
         )
     return (
-        f"👑 <b>SPO-eligible GA</b>\n"
-        f"Type: {ctx['action_label']}\n"
-        f"Consider casting a vote on behalf of your pool.\n"
-        f"{ctx['gov_url']}"
+        "<b>👑 Cardanoism — SPO-eligible Governance Action</b>\n"
+        "\n"
+        f"📋 Proposal Type: {ctx['action_label']}\n"
+        "\n"
+        "A new governance action eligible for SPO voting has been submitted.\n"
+        "Consider casting a vote on behalf of your pool.\n"
+        "\n"
+        f'→ <a href="{ctx["proposal_url"]}">View proposal</a>'
     )
 
 

--- a/cardanoism/backend/notify_templates/treasury_withdrawal_enacted.py
+++ b/cardanoism/backend/notify_templates/treasury_withdrawal_enacted.py
@@ -53,16 +53,24 @@ def render_email(ctx: dict, lang: str) -> tuple[str, list[str], str, str]:
 def render_telegram(ctx: dict, lang: str) -> str:
     if lang == "ja":
         return (
-            f"🏛️ <b>トレジャリー引き出しが施行</b>\n"
-            f"タイトル: {ctx['proposal_title']}\n"
-            f"施行エポック: Epoch {ctx['enacted_epoch']}\n"
-            f"{ctx['proposal_url']}"
+            "<b>🏛️ Cardanoism — トレジャリー引き出し施行通知</b>\n"
+            "\n"
+            f"📋 提案タイトル: {ctx['proposal_title']}\n"
+            f"📅 施行エポック: Epoch {ctx['enacted_epoch']}\n"
+            "\n"
+            "トレジャリー引き出しが施行されました。\n"
+            "\n"
+            f'→ <a href="{ctx["proposal_url"]}">提案を確認する</a>'
         )
     return (
-        f"🏛️ <b>Treasury Withdrawal Enacted</b>\n"
-        f"Title: {ctx['proposal_title']}\n"
-        f"Enacted Epoch: {ctx['enacted_epoch']}\n"
-        f"{ctx['proposal_url']}"
+        "<b>🏛️ Cardanoism — Treasury Withdrawal Enacted</b>\n"
+        "\n"
+        f"📋 Proposal Title: {ctx['proposal_title']}\n"
+        f"📅 Enacted Epoch: {ctx['enacted_epoch']}\n"
+        "\n"
+        "A treasury withdrawal has been enacted.\n"
+        "\n"
+        f'→ <a href="{ctx["proposal_url"]}">View proposal</a>'
     )
 
 

--- a/notify_worker.py
+++ b/notify_worker.py
@@ -688,6 +688,7 @@ def _check_pool_reward_received_batch(
             nickname=addr["nickname"],
             is_leader=is_spo,
             base_url=CARDANOISM_URL,
+            pool_name=addr.get("delegated_pool_name") or "",
         )
         deliver(addr, EVENT_TYPE, ctx, dedup_base=f"reward_{addr['stake_id']}_{reward_epoch}")
 
@@ -2110,7 +2111,9 @@ _DUMMY = {
     "active_stake_ada": 5_000_000.0,
     "saturation_pct": 78.5,
     "block_cnt": 3,
-    "proposal_title": "Treasury Withdrawal — DUMMY Title",
+    "proposal_title": "DUMMY Title",
+    "proposal_id": "gov_action1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "proposal_action_type_raw": "treasuryWithdrawals",
     "proposal_action_type_ja": "国庫引き出し",
     "proposal_action_type_en": "Treasury Withdrawals",
     "old_margin_pct": 1.0,
@@ -2190,11 +2193,13 @@ def _build_dummy_ctx(ev: str) -> tuple[str, dict] | None:
         return ("pool_reward_received", pool_reward_received.context(
             reward_epoch=d["reward_epoch"], primary_ada=d["amount_ada"],
             apy=d["apy"], nickname=d["nickname"], is_leader=False, base_url=base_url,
+            pool_name=d["pool_name"],
         ))
     if ev == "pool_reward_received_leader":
         return ("pool_reward_received", pool_reward_received.context(
             reward_epoch=d["reward_epoch"], primary_ada=d["leader_amount_ada"],
             apy=d["apy"], nickname=d["nickname"], is_leader=True, base_url=base_url,
+            pool_name=d["pool_name"],
         ))
     if ev == "pool_epoch_performance":
         return ("pool_epoch_performance", pool_epoch_performance.context(
@@ -2211,11 +2216,14 @@ def _build_dummy_ctx(ev: str) -> tuple[str, dict] | None:
     if ev == "drep_new_governance_action":
         return ("drep_new_governance_action", drep_new_governance_action.context(
             action_label=action_label, base_url=base_url,
+            proposal_id=d["proposal_id"],
         ))
     if ev == "drep_vote":
         return ("drep_vote", drep_vote.context(
             drep_name=d["drep_name"], vote="yes", proposal_title=d["proposal_title"],
             nickname=d["nickname"], base_url=base_url,
+            action_type=d["proposal_action_type_raw"],
+            proposal_id=d["proposal_id"],
         ))
     if ev == "drep_status_change":
         return ("drep_status_change", drep_status_change.context(
@@ -2235,6 +2243,7 @@ def _build_dummy_ctx(ev: str) -> tuple[str, dict] | None:
     if ev == "spo_pending_vote":
         return ("spo_pending_vote", spo_pending_vote.context(
             action_label=action_label, base_url=base_url,
+            proposal_id=d["proposal_id"],
         ))
     return None
 

--- a/ogmios_listener.py
+++ b/ogmios_listener.py
@@ -41,7 +41,7 @@ from notify_worker import (
 )
 from cardanoism.backend import line_flex
 from cardanoism.backend.mail_notify import build_html, build_text
-from cardanoism.backend.koios import get_proposal_title, get_pool_name, get_pool_epoch_stats, get_pool_apy
+from cardanoism.backend.koios import get_proposal_title, get_proposal_info, get_pool_name, get_pool_epoch_stats, get_pool_apy
 from cardanoism.backend.recent_blocks_db import insert_block, trim_old_blocks, delete_blocks_after_slot
 from cardanoism.backend.mempool_db import upsert_mempool_state
 from cardanoism.backend.listener_db import rollback_listener_state
@@ -334,11 +334,12 @@ def _notify_pool_fee_change(pool_id: str, margin: float, fixed_cost: int, pledge
 # 通知発火: drep_new_governance_action
 # ──────────────────────────────────────────────────────────────────────────────
 
-def _notify_governance_action(tx_id: str, action_type_raw: str) -> None:
+def _notify_governance_action(tx_id: str, proposal_idx: int, action_type_raw: str) -> None:
     from cardanoism.backend.notify_templates import deliver
     from cardanoism.backend.notify_templates.drep_new_governance_action import (
         context as build_ctx, EVENT_TYPE,
     )
+    from cardanoism.backend.listener_governance import encode_proposal_id
 
     addrs = _merge_stake_channels(
         get_stake_addrs_with_event("drep_new_governance_action"),
@@ -348,18 +349,20 @@ def _notify_governance_action(tx_id: str, action_type_raw: str) -> None:
     if not addrs:
         return
 
+    proposal_id = encode_proposal_id(tx_id, proposal_idx) or ""
+
     for addr in addrs:
         lang = addr.get("language", "ja")
         label = (_GA_TYPE_MAP_JA if lang == "ja" else _GA_TYPE_MAP_EN).get(action_type_raw, action_type_raw)
-        ctx = build_ctx(action_label=label, base_url=CARDANOISM_URL)
-        deliver(addr, EVENT_TYPE, ctx, dedup_base=f"new_gov_{tx_id}_{addr['stake_id']}")
+        ctx = build_ctx(action_label=label, base_url=CARDANOISM_URL, proposal_id=proposal_id)
+        deliver(addr, EVENT_TYPE, ctx, dedup_base=f"new_gov_{tx_id}_{proposal_idx}_{addr['stake_id']}")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
 # 通知発火: spo_pending_vote (SPO 対象 GA が新規提出された)
 # ──────────────────────────────────────────────────────────────────────────────
 
-def _notify_spo_pending_vote(tx_id: str, action_type_raw: str) -> None:
+def _notify_spo_pending_vote(tx_id: str, proposal_idx: int, action_type_raw: str) -> None:
     """SPO 対象の新規 GA が提出されたとき、SPO 設定があるユーザーへ催促通知。
 
     対象判定は spo_pool_id が NULL でない stake_address のみ。通知設定 spo_pending_vote
@@ -369,6 +372,7 @@ def _notify_spo_pending_vote(tx_id: str, action_type_raw: str) -> None:
     from cardanoism.backend.notify_templates.spo_pending_vote import (
         context as build_ctx, EVENT_TYPE,
     )
+    from cardanoism.backend.listener_governance import encode_proposal_id
 
     addrs = _merge_stake_channels(
         get_stake_addrs_with_event("spo_pending_vote"),
@@ -379,12 +383,14 @@ def _notify_spo_pending_vote(tx_id: str, action_type_raw: str) -> None:
     if not addrs:
         return
 
+    proposal_id = encode_proposal_id(tx_id, proposal_idx) or ""
+
     for addr in addrs:
         lang = addr.get("language", "ja")
         label = (_GA_TYPE_MAP_JA if lang == "ja" else _GA_TYPE_MAP_EN).get(action_type_raw, action_type_raw)
-        ctx = build_ctx(action_label=label, base_url=CARDANOISM_URL)
+        ctx = build_ctx(action_label=label, base_url=CARDANOISM_URL, proposal_id=proposal_id)
         deliver(addr, EVENT_TYPE, ctx,
-                dedup_base=f"spo_pending_{tx_id}_{addr['stake_id']}")
+                dedup_base=f"spo_pending_{tx_id}_{proposal_idx}_{addr['stake_id']}")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -405,13 +411,17 @@ def _notify_drep_vote(drep_id: str, vote_str: str, gov_tx_hash: str, gov_index: 
     if not addrs:
         return
 
-    proposal_title = get_proposal_title(gov_tx_hash, gov_index) if gov_tx_hash else None
+    info = get_proposal_info(gov_tx_hash, gov_index) if gov_tx_hash else None
+    proposal_title = (info or {}).get("title") or None
+    action_type    = (info or {}).get("proposal_type") or None
+    proposal_id    = (info or {}).get("proposal_id") or None
 
     for addr in addrs:
         drep_name = addr.get("delegated_drep_name") or drep_id[:12]
         ctx = build_ctx(
             drep_name=drep_name, vote=vote_str, proposal_title=proposal_title,
             nickname=addr["nickname"], base_url=CARDANOISM_URL,
+            action_type=action_type, proposal_id=proposal_id,
         )
         deliver(addr, EVENT_TYPE, ctx,
                 dedup_base=f"drep_vote_{addr['stake_id']}_{gov_tx_hash}_{gov_index}")
@@ -525,14 +535,14 @@ def _process_tx(tx: dict, slot: int, current_epoch: int) -> None:
             except Exception as e:
                 logger.exception("listener: GA DB 書込み失敗 tx=%s idx=%d: %s", tx_id, proposal_idx, e)
             # 通知発火: 全員向け (drep_new_governance_action)
-            _notify_governance_action(tx_id, action_type)
+            _notify_governance_action(tx_id, proposal_idx, action_type)
             # SPO 対象の場合は SPO 専用通知も発火
             try:
                 from cardanoism.backend.spo_targets import compute_spo_target
                 from cardanoism.backend.listener_governance import _ACTION_TYPE_MAP
                 proposal_type_pascal = _ACTION_TYPE_MAP.get(action_type, action_type)
                 if compute_spo_target(proposal_type_pascal, proposal.get("action")):
-                    _notify_spo_pending_vote(tx_id, action_type)
+                    _notify_spo_pending_vote(tx_id, proposal_idx, action_type)
             except Exception as e:
                 logger.exception("listener: spo_pending_vote 通知失敗: %s", e)
         except Exception as e:


### PR DESCRIPTION
全 14 通知の render_telegram を以下の共通フォーマットに刷新:

- ヘッダー: <b>絵文字 Cardanoism — イベント名</b>
- セクション間に空行で視認性向上
- 項目ごとに絵文字ラベル (🏊 プール / 👤 DRep / 💼 ウォレット など)
- CTA は <a href> でクリッカブル化、URL 文字列を露出させない

データ拡張:
- drep_vote: action_type / proposal_id を context に追加し GA 個別ページへリンク
  + 「投票内容がご自身の意思と異なる場合は委任先 DRep を変更できる」案内 + マイページ委任変更リンクを追加
- drep_new_governance_action / spo_pending_vote: encode_proposal_id() で proposal_id を計算し GA 個別ページにリンク
- pool_reward_received: pool_name を context に追加
- koios: get_proposal_info() で title + proposal_id + proposal_type を一括取得