### PR TITLE
feat(governance): DRep × GA 投票マトリクスページ追加 + TOP 機能 6 枚を再構成

### DIFF
--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -231,7 +231,24 @@ UI_JA: dict[str, str] = {
     "gov_subnav_actions": "ガバナンス提案",
     "gov_subnav_drep": "代表者 (DRep)",
     "gov_subnav_treasury": "トレジャリー",
+    "gov_subnav_matrix": "投票マトリクス",
     "gov_subnav_constitution": "Cardano 憲法",
+
+    # 投票マトリクスページ
+    "matrix_title":              "DRep × ガバナンス提案 投票マトリクス",
+    "matrix_desc":               "登録 DRep が現在進行中のガバナンス提案にどう投票したか早見表で確認できます。セルにマウスを乗せると投票理由が表示されます。",
+    "matrix_search_placeholder": "DRep 名で検索",
+    "matrix_status_label":       "ステータス",
+    "matrix_gas_per_page":       "GA 最大表示数",
+    "matrix_gas_total":          "GA 総数:",
+    "matrix_per_page":           "DRep 最大表示数",
+    "matrix_col_drep":           "DRep",
+    "matrix_total":              "登録 DRep 総数:",
+    "matrix_empty":              "表示できる DRep がありません。",
+    "matrix_legend_yes":         "賛成",
+    "matrix_legend_no":          "反対",
+    "matrix_legend_abstain":     "棄権",
+    "matrix_legend_no_vote":     "未投票",
 
     # ── /governance/why 啓発ページ ──
     # S1: ガバナンスとは？
@@ -645,21 +662,21 @@ UI_JA: dict[str, str] = {
 
     # ── 新ホーム: Feature Showcase ──────────────────────────
     "home_features_kicker":      "FEATURES",
-    "home_features_title":       "ガバナンス参加を加速する 6 つの機能",
-    "home_features_subtitle":    "登録したステークアドレスを起点に、提案の理解から投票判断まで一気通貫でサポートします。",
+    "home_features_title":       "カルダノ参加を身近にする 6 つの機能",
+    "home_features_subtitle":    "ステーキング・ガバナンス・Catalyst を 1 つのダッシュボードで。委任手続きから通知・投票判断まで、必要な情報と操作をまとめて提供します。",
 
-    "home_f_ai_title":           "AI による提案の自動整理",
-    "home_f_ai_desc":            "GA 提案を中立的に要約し、引き出し額・受取先・期間などのキーファクトを自動抽出。",
-    "home_f_drep_title":         "委任先 DRep の投票表示",
-    "home_f_drep_desc":          "登録ステークアドレスから委任先 DRep を引き、各 GA への投票結果と理由を一目で確認。",
-    "home_f_constitution_title": "Cardano 憲法 完全日本語訳",
-    "home_f_constitution_desc":  "施行中の最新バージョンの原文と日本語訳を並列表示。改訂時も自動追従します。",
+    "home_f_notify_title":       "ステーキング報酬とプール状態を即時通知",
+    "home_f_notify_desc":        "エポック報酬入金・プール手数料・飽和度・誓約変化を LINE / Telegram / メールで即時配信。",
+    "home_f_wallet_title":       "ウォレット連携で委任もブラウザ完結",
+    "home_f_wallet_desc":        "Cardano ウォレットを接続して、プール委任・DRep 委任の手続きをサイト内で完結。",
+    "home_f_ai_title":           "AI 提案要約 + 全 DRep 投票早見表",
+    "home_f_ai_desc":            "GA を AI が中立的に要約し、登録 DRep の投票結果と理由をマトリクスで一覧確認。",
+    "home_f_catalyst_title":     "Catalyst 提案を一画面で管理",
+    "home_f_catalyst_desc":      "Fund・ステータスで絞り込み、お気に入り保存、進捗追跡まで Catalyst をワンストップ。",
     "home_f_treasury_title":     "トレジャリー残高グラフ",
     "home_f_treasury_desc":      "NCL 期間中のエポック別残高推移と引き出し履歴を可視化。",
-    "home_f_notify_title":       "リアルタイム通知",
-    "home_f_notify_desc":        "報酬・DRep 投票・プール変化を LINE / Telegram / Email で即時配信。",
-    "home_f_ga_title":           "ガバナンスアクション日本語化",
-    "home_f_ga_desc":            "提出された全 GA のタイトル・本文・条件をリアルタイムで日本語化し、原文と並列で表示。",
+    "home_f_constitution_title": "Cardano 憲法 完全日本語訳",
+    "home_f_constitution_desc":  "施行中の最新バージョンの原文と日本語訳を並列表示。改訂時も自動追従します。",
 
     # ── 新ホーム: Constitution Highlight ────────────────────
     "home_constitution_kicker":     "CARDANO CONSTITUTION",
@@ -972,7 +989,24 @@ UI_EN: dict[str, str] = {
     "gov_subnav_actions": "GA Proposals",
     "gov_subnav_drep": "DReps",
     "gov_subnav_treasury": "Treasury",
+    "gov_subnav_matrix": "Vote Matrix",
     "gov_subnav_constitution": "Constitution",
+
+    # Vote matrix page
+    "matrix_title":              "DRep × Governance Action Vote Matrix",
+    "matrix_desc":               "Quick-reference matrix of how registered DReps voted on currently active governance actions. Hover a cell to see the vote rationale.",
+    "matrix_search_placeholder": "Search DRep name",
+    "matrix_status_label":       "Status",
+    "matrix_gas_per_page":       "Max GAs shown",
+    "matrix_gas_total":          "Total GAs:",
+    "matrix_per_page":           "Max DReps shown",
+    "matrix_col_drep":           "DRep",
+    "matrix_total":              "Total DReps:",
+    "matrix_empty":              "No DReps to display.",
+    "matrix_legend_yes":         "Yes",
+    "matrix_legend_no":          "No",
+    "matrix_legend_abstain":     "Abstain",
+    "matrix_legend_no_vote":     "Not voted",
 
     # ── /governance/why page ──
     # S1: What is governance?
@@ -1378,21 +1412,21 @@ UI_EN: dict[str, str] = {
 
     # ── New home: Feature Showcase ──
     "home_features_kicker":      "FEATURES",
-    "home_features_title":       "Six tools to accelerate your governance participation",
-    "home_features_subtitle":    "From understanding proposals to making your vote decision — Cardanoism guides you end-to-end based on your registered stake addresses.",
+    "home_features_title":       "Six tools that bring Cardano participation closer",
+    "home_features_subtitle":    "Manage staking, governance, and Catalyst from a single dashboard. From delegation to notifications and vote decisions — everything you need in one place.",
 
-    "home_f_ai_title":           "AI proposal summary",
-    "home_f_ai_desc":            "Neutral 6–10 sentence summaries plus auto-extracted key facts (amount, recipient, period, etc.).",
-    "home_f_drep_title":         "Your DRep's vote",
-    "home_f_drep_desc":          "Look up how your delegated DRep voted on each GA, including their rationale.",
-    "home_f_constitution_title": "Cardano Constitution in Japanese",
-    "home_f_constitution_desc":  "Current ratified version shown side-by-side: original English + Japanese translation.",
+    "home_f_notify_title":       "Real-time staking & pool alerts",
+    "home_f_notify_desc":        "Reward arrivals, pool fees, saturation, and pledge changes — pushed instantly via LINE / Telegram / Email.",
+    "home_f_wallet_title":       "Browser-native delegation via wallet",
+    "home_f_wallet_desc":        "Connect your Cardano wallet to delegate to pools or DReps directly on Cardanoism.",
+    "home_f_ai_title":           "AI summaries + DRep vote matrix",
+    "home_f_ai_desc":            "Neutral AI summaries of GAs plus a quick-reference matrix of how registered DReps voted, with rationales.",
+    "home_f_catalyst_title":     "Catalyst proposals at a glance",
+    "home_f_catalyst_desc":      "Filter by Fund and status, save favorites, and track funding outcomes — Catalyst made simple.",
     "home_f_treasury_title":     "Treasury balance chart",
     "home_f_treasury_desc":      "Per-epoch treasury balance trend across the active NCL period, plus withdrawal history.",
-    "home_f_notify_title":       "Real-time notifications",
-    "home_f_notify_desc":        "Push rewards, DRep votes, and pool changes via LINE / Telegram / Email.",
-    "home_f_ga_title":           "Governance actions in Japanese",
-    "home_f_ga_desc":            "Every submitted GA's title, body, and conditions translated to Japanese in real time, shown side-by-side with the original.",
+    "home_f_constitution_title": "Cardano Constitution in Japanese",
+    "home_f_constitution_desc":  "Original English alongside the AI-translated Japanese version. Always synced to the latest enacted version.",
 
     # ── New home: Constitution Highlight ──
     "home_constitution_kicker":     "CARDANO CONSTITUTION",

--- a/cardanoism/backend/vote_matrix_db.py
+++ b/cardanoism/backend/vote_matrix_db.py
@@ -1,0 +1,156 @@
+"""vote_matrix_db.py
+DRep × GA 投票マトリクスのデータ取得ヘルパー (読み取り専用)。
+
+使用テーブル: governance_actions / proposal_votes / dreps
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from cardanoism.backend.db_connect import get_db
+
+
+VALID_GA_STATUSES = ("active", "ratified", "enacted", "dropped", "expired")
+
+
+def _ga_status_where(status: str) -> str:
+    """ステータス文字列から WHERE 句を生成 (LIMIT/OFFSET なし)。"""
+    if status not in VALID_GA_STATUSES:
+        status = "active"
+    if status == "active":
+        return (
+            " WHERE ratified_epoch IS NULL"
+            "   AND enacted_epoch  IS NULL"
+            "   AND dropped_epoch  IS NULL"
+            "   AND expired_epoch  IS NULL"
+        )
+    col = f"{status}_epoch"
+    return f" WHERE {col} IS NOT NULL"
+
+
+def count_gas_for_matrix(*, status: str = "active") -> int:
+    """指定ステータスの GA 件数を返す (ページネーション用)。"""
+    where = _ga_status_where(status)
+    sql = f"SELECT COUNT(*) AS n FROM governance_actions {where}"
+    with get_db() as (cursor, _):
+        cursor.execute(sql)
+        row = cursor.fetchone()
+        if not row:
+            return 0
+        return int(dict(row).get("n") or 0)
+
+
+def get_gas_for_matrix(
+    *, status: str = "active", limit: int = 30, offset: int = 0
+) -> list[dict[str, Any]]:
+    """指定ステータスの GA 一覧を返す。
+
+    status:
+      - "active":   ratified/enacted/dropped/expired すべて NULL（投票進行中）
+      - "ratified": ratified_epoch が NOT NULL
+      - "enacted":  enacted_epoch  が NOT NULL
+      - "dropped":  dropped_epoch  が NOT NULL
+      - "expired":  expired_epoch  が NOT NULL
+
+    proposed_epoch DESC で並べる（直近提出順）。limit/offset でページング。
+
+    戻り値要素: {proposal_id, title, title_ja, proposal_type, expiration, proposed_epoch}
+    """
+    where = _ga_status_where(status)
+    sql = f"""
+        SELECT proposal_id,
+               title,
+               title_ja,
+               proposal_type,
+               expiration,
+               proposed_epoch
+          FROM governance_actions
+          {where}
+         ORDER BY proposed_epoch DESC, id DESC
+         LIMIT ? OFFSET ?
+    """
+    with get_db() as (cursor, _):
+        cursor.execute(sql, (int(limit), int(offset)))
+        return [dict(r) for r in cursor.fetchall()]
+
+
+def get_active_gas() -> list[dict[str, Any]]:
+    """後方互換のための薄いラッパー。新規コードは get_gas_for_matrix() を使う。"""
+    return get_gas_for_matrix(status="active", limit=10000, offset=0)
+
+
+def count_dreps_for_matrix(*, search: str = "") -> int:
+    """マトリクス対象 DRep の総数。registered=1 のみ。"""
+    where = "WHERE registered = 1"
+    params: list = []
+    if search:
+        where += " AND (given_name LIKE ? OR drep_id LIKE ?)"
+        like = f"%{search}%"
+        params += [like, like]
+    sql = f"SELECT COUNT(*) AS n FROM dreps {where}"
+    with get_db() as (cursor, _):
+        cursor.execute(sql, tuple(params))
+        row = cursor.fetchone()
+        if not row:
+            return 0
+        return int(dict(row).get("n") or 0)
+
+
+def get_dreps_for_matrix(
+    *, search: str = "", limit: int = 50, offset: int = 0
+) -> list[dict[str, Any]]:
+    """マトリクスの行 (DRep) を取得。registered=1 のみ、amount 降順。"""
+    where = "WHERE registered = 1"
+    params: list = []
+    if search:
+        where += " AND (given_name LIKE ? OR drep_id LIKE ?)"
+        like = f"%{search}%"
+        params += [like, like]
+    sql = f"""
+        SELECT drep_id, given_name, image_url, drep_status, active, amount
+          FROM dreps
+          {where}
+         ORDER BY amount DESC
+         LIMIT ? OFFSET ?
+    """
+    params += [int(limit), int(offset)]
+    with get_db() as (cursor, _):
+        cursor.execute(sql, tuple(params))
+        return [dict(r) for r in cursor.fetchall()]
+
+
+def get_votes_for_matrix(
+    drep_ids: list[str], proposal_ids: list[str]
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """指定 DRep × GA の投票レコードを取得。
+
+    戻り値: {(drep_id, proposal_id): {vote, rationale, rationale_ja}}
+    投票レコードが存在しない組み合わせは含まれない。
+    """
+    if not drep_ids or not proposal_ids:
+        return {}
+    placeholders_d = ",".join(["?"] * len(drep_ids))
+    placeholders_p = ",".join(["?"] * len(proposal_ids))
+    sql = f"""
+        SELECT voter_id    AS drep_id,
+               proposal_id,
+               vote,
+               rationale,
+               rationale_ja
+          FROM proposal_votes
+         WHERE voter_role = 'DRep'
+           AND voter_id    IN ({placeholders_d})
+           AND proposal_id IN ({placeholders_p})
+    """
+    params = list(drep_ids) + list(proposal_ids)
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    with get_db() as (cursor, _):
+        cursor.execute(sql, tuple(params))
+        for r in cursor.fetchall():
+            d = dict(r)
+            out[(d["drep_id"], d["proposal_id"])] = {
+                "vote":         d.get("vote") or "",
+                "rationale":    d.get("rationale") or "",
+                "rationale_ja": d.get("rationale_ja") or "",
+            }
+    return out

--- a/cardanoism/components/governance_nav.py
+++ b/cardanoism/components/governance_nav.py
@@ -52,13 +52,14 @@ def governance_subnav(active: str) -> rx.Component:
     """ガバナンス共通のサブナビゲーション。
 
     Args:
-        active: 現在のタブ（"why" | "actions" | "treasury" | "drep" | "constitution"）
+        active: 現在のタブ（"why" | "actions" | "matrix" | "treasury" | "drep" | "constitution"）
 
-    並び順: ガバナンスとは → ガバナンス提案 → トレジャリー → DRep 一覧 → Cardano 憲法
+    並び順: ガバナンスとは → ガバナンス提案 → 投票マトリクス → トレジャリー → DRep 一覧 → Cardano 憲法
     """
     return rx.hstack(
         _pill(AuthState.t["gov_subnav_why"], "/governance/why", "lightbulb", active == "why"),
         _pill(AuthState.t["gov_subnav_actions"], "/governance", "gavel", active == "actions"),
+        _pill(AuthState.t["gov_subnav_matrix"], "/governance/matrix", "table-2", active == "matrix"),
         _pill(AuthState.t["gov_subnav_treasury"], "/governance/treasury", "landmark", active == "treasury"),
         _pill(AuthState.t["gov_subnav_drep"], "/governance/drep", "users", active == "drep"),
         _pill(AuthState.t["gov_subnav_constitution"], "/governance/constitution", "scroll-text", active == "constitution"),

--- a/cardanoism/components/navbar.py
+++ b/cardanoism/components/navbar.py
@@ -263,6 +263,7 @@ def navbar_icons() -> rx.Component:
                     [
                         ("lightbulb",    AuthState.t["gov_subnav_why"],          "/governance/why"),
                         ("gavel",        AuthState.t["gov_subnav_actions"],      "/governance"),
+                        ("table-2",      AuthState.t["gov_subnav_matrix"],       "/governance/matrix"),
                         ("landmark",     AuthState.t["gov_subnav_treasury"],     "/governance/treasury"),
                         ("users",        AuthState.t["gov_subnav_drep"],         "/governance/drep"),
                         ("scroll-text",  AuthState.t["gov_subnav_constitution"], "/governance/constitution"),

--- a/cardanoism/pages/__init__.py
+++ b/cardanoism/pages/__init__.py
@@ -11,6 +11,7 @@ from .governance_why import governance_why_page
 from .governance_treasury import governance_treasury_page
 from .governance_drep import governance_drep_page
 from .governance_drep_detail import governance_drep_detail_page
+from .governance_matrix import governance_matrix_page
 from .constitution import constitution_page
 from .staking import staking_page
 from .staking_spo import staking_spo_page

--- a/cardanoism/pages/governance_matrix.py
+++ b/cardanoism/pages/governance_matrix.py
@@ -1,0 +1,774 @@
+"""governance_matrix.py
+DRep × GA 投票マトリクスページ (/governance/matrix)
+
+横軸: Active な GA、縦軸: 登録済み DRep。
+セルに ✅ / ❌ / ⚪ / — の投票結果と、投票理由をマウスオーバーで表示。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, TypedDict
+
+import reflex as rx
+
+
+class GA(TypedDict):
+    proposal_id: str
+    title: str
+    title_ja: str
+    proposal_type: str
+
+
+class Cell(TypedDict):
+    vote: str
+    icon: str
+    color: str
+    rationale: str
+    rationale_ja: str
+    proposal_id: str
+
+
+class Row(TypedDict):
+    drep_id: str
+    drep_id_short: str
+    given_name: str
+    image_url: str
+    active: str
+    cells: list[Cell]
+
+from cardanoism.templates import template
+from cardanoism.backend.auth_state import AuthState
+from cardanoism.backend.vote_matrix_db import (
+    get_gas_for_matrix,
+    count_gas_for_matrix,
+    count_dreps_for_matrix,
+    get_dreps_for_matrix,
+    get_votes_for_matrix,
+)
+from cardanoism.components.governance_nav import governance_subnav
+
+logger = logging.getLogger(__name__)
+
+
+_PER_PAGE_OPTIONS = ["20", "50", "100"]
+DEFAULT_PER_PAGE = 50
+
+# GA 列のページサイズ。20/30/50 から選択（パフォーマンス上の上限）
+_GA_PER_PAGE_OPTIONS = ["20", "30", "50"]
+DEFAULT_GA_PER_PAGE = 30
+
+# 投票理由ツールチップの最大文字数（長すぎるとブラウザが切る）
+_RATIONALE_MAX_CHARS = 600
+
+
+def _trim(s: str, n: int = _RATIONALE_MAX_CHARS) -> str:
+    if not s:
+        return ""
+    s = s.strip()
+    if len(s) <= n:
+        return s
+    return s[:n].rstrip() + "…"
+
+
+# ─── State ────────────────────────────────────────────────────────────────────
+
+
+class VoteMatrixState(rx.State):
+    load: bool = False
+    error: str = ""
+
+    inputed_value: str = ""
+    search_query: str = ""
+
+    # GA 列のステータスフィルタ ("active" / "ratified" / "enacted" / "dropped" / "expired")
+    ga_status: str = "active"
+
+    # DRep 行のページネーション
+    items_per_page: int = DEFAULT_PER_PAGE
+    current_page: int = 1
+    total_pages: int = 1
+    total_items: int = 0
+
+    start_page: int = 1
+    end_page: int = 1
+    middle_page: list[int] = []
+
+    # GA 列のページネーション
+    gas_per_page: int = DEFAULT_GA_PER_PAGE
+    gas_current_page: int = 1
+    gas_total_pages: int = 1
+    gas_total_items: int = 0
+
+    gas_start_page: int = 1
+    gas_end_page: int = 1
+    gas_middle_page: list[int] = []
+
+    # マトリクスデータ
+    # gas: 横軸（GA 列）
+    gas: list[GA] = []
+    # matrix_rows: 縦軸（DRep 行）。各 row に cells (GA 順に並んだ投票セル) を持たせる
+    matrix_rows: list[Row] = []
+
+    def _fetch(self):
+        try:
+            # GA 列のページング
+            gas_total = count_gas_for_matrix(status=self.ga_status)
+            self.gas_total_items = gas_total
+            self.gas_total_pages = max(1, (gas_total + self.gas_per_page - 1) // self.gas_per_page)
+            # 現在のページが範囲外なら 1 に戻す
+            if self.gas_current_page > self.gas_total_pages:
+                self.gas_current_page = 1
+            gas_offset = (self.gas_current_page - 1) * self.gas_per_page
+            self.gas_start_page = max(1, self.gas_current_page - 3)
+            self.gas_end_page   = min(self.gas_total_pages, self.gas_current_page + 3)
+            self.gas_middle_page = list(range(self.gas_start_page, self.gas_end_page + 1))
+
+            gas_raw = get_gas_for_matrix(
+                status=self.ga_status,
+                limit=self.gas_per_page,
+                offset=gas_offset,
+            )
+            self.gas = [
+                {
+                    "proposal_id":   g["proposal_id"],
+                    "title":         g.get("title") or "",
+                    "title_ja":      g.get("title_ja") or "",
+                    "proposal_type": g.get("proposal_type") or "",
+                }
+                for g in gas_raw
+            ]
+            proposal_ids = [g["proposal_id"] for g in self.gas]
+
+            # DRep 行のページング
+            offset = (self.current_page - 1) * self.items_per_page
+            dreps = get_dreps_for_matrix(
+                search=self.search_query,
+                limit=self.items_per_page,
+                offset=offset,
+            )
+            total = count_dreps_for_matrix(search=self.search_query)
+            self.total_items = total
+            self.total_pages = max(1, (total + self.items_per_page - 1) // self.items_per_page)
+            self.start_page = max(1, self.current_page - 3)
+            self.end_page   = min(self.total_pages, self.current_page + 3)
+            self.middle_page = list(range(self.start_page, self.end_page + 1))
+
+            drep_ids = [d["drep_id"] for d in dreps]
+            votes = get_votes_for_matrix(drep_ids, proposal_ids)
+
+            rows: list[dict[str, Any]] = []
+            for d in dreps:
+                drep_id = d["drep_id"]
+                cells: list[dict[str, str]] = []
+                for g in self.gas:
+                    vk = votes.get((drep_id, g["proposal_id"]))
+                    if vk is None:
+                        cells.append({
+                            "vote":         "",
+                            "icon":         "—",
+                            "color":        "var(--gray-9)",
+                            "rationale":    "",
+                            "rationale_ja": "",
+                            "proposal_id":  g["proposal_id"],
+                        })
+                    else:
+                        v = (vk.get("vote") or "").lower()
+                        if v == "yes":
+                            icon, color = "Y", "var(--green-10)"
+                        elif v == "no":
+                            icon, color = "N", "var(--red-10)"
+                        elif v == "abstain":
+                            icon, color = "×", "var(--gray-10)"
+                        else:
+                            icon, color = "?", "var(--gray-9)"
+                        cells.append({
+                            "vote":         v,
+                            "icon":         icon,
+                            "color":        color,
+                            "rationale":    _trim(vk.get("rationale") or ""),
+                            "rationale_ja": _trim(vk.get("rationale_ja") or ""),
+                            "proposal_id":  g["proposal_id"],
+                        })
+                drep_id_short = (
+                    drep_id[:10] + "…" + drep_id[-6:] if len(drep_id) > 24 else drep_id
+                )
+                rows.append({
+                    "drep_id":       drep_id,
+                    "drep_id_short": drep_id_short,
+                    "given_name":    d.get("given_name") or "",
+                    "image_url":     d.get("image_url") or "",
+                    "active":        "1" if d.get("active") else "",
+                    "cells":         cells,
+                })
+            self.matrix_rows = rows
+        except Exception as e:  # noqa: BLE001
+            logger.exception("VoteMatrixState._fetch: %s", e)
+            self.error = str(e)
+
+    def on_load(self):
+        self.load = False
+        self.error = ""
+        self.inputed_value = ""
+        self.search_query = ""
+        self.ga_status = "active"
+        self.items_per_page = DEFAULT_PER_PAGE
+        self.current_page = 1
+        self.gas_per_page = DEFAULT_GA_PER_PAGE
+        self.gas_current_page = 1
+        self._fetch()
+        self.load = True
+
+    def set_ga_status(self, status: str):
+        # 不正値はガード
+        if status not in ("active", "ratified", "enacted", "dropped", "expired"):
+            return
+        self.ga_status = status
+        self.current_page = 1
+        self.gas_current_page = 1
+        self._fetch()
+
+    def set_gas_per_page(self, v: str):
+        try:
+            n = int(v)
+        except (TypeError, ValueError):
+            return
+        if n in (20, 30, 50):
+            self.gas_per_page = n
+            self.gas_current_page = 1
+            self._fetch()
+
+    def set_gas_page(self, p):
+        try:
+            self.gas_current_page = int(p)
+            self._fetch()
+        except (TypeError, ValueError):
+            pass
+
+    def prev_gas_page(self):
+        if self.gas_current_page > 1:
+            self.gas_current_page -= 1
+            self._fetch()
+
+    def next_gas_page(self):
+        if self.gas_current_page < self.gas_total_pages:
+            self.gas_current_page += 1
+            self._fetch()
+
+    def set_search(self, v: str):
+        self.inputed_value = v
+        self.search_query = v
+        self.current_page = 1
+        self._fetch()
+
+    def set_per_page(self, v: str):
+        try:
+            n = int(v)
+        except (TypeError, ValueError):
+            return
+        if n in (20, 50, 100):
+            self.items_per_page = n
+            self.current_page = 1
+            self._fetch()
+
+    def set_page(self, p):
+        try:
+            self.current_page = int(p)
+            self._fetch()
+        except (TypeError, ValueError):
+            pass
+        return rx.call_script("window.scrollTo(0, 0)")
+
+    def prev_page(self):
+        if self.current_page > 1:
+            self.current_page -= 1
+            self._fetch()
+        return rx.call_script("window.scrollTo(0, 0)")
+
+    def next_page(self):
+        if self.current_page < self.total_pages:
+            self.current_page += 1
+            self._fetch()
+        return rx.call_script("window.scrollTo(0, 0)")
+
+
+# ─── UI ───────────────────────────────────────────────────────────────────────
+
+
+def _breadcrumb() -> rx.Component:
+    return rx.hstack(
+        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
+        rx.icon("chevron-right", size=14, color="gray"),
+        rx.link(AuthState.t["nav_governance"], href="/governance",
+                size="2", underline="hover", color_scheme="gray"),
+        rx.icon("chevron-right", size=14, color="gray"),
+        rx.text(AuthState.t["gov_subnav_matrix"], size="2", weight="medium"),
+        spacing="2",
+        align="center",
+        width="100%",
+        padding_top="15px",
+    )
+
+
+def _filter_bar() -> rx.Component:
+    return rx.flex(
+        rx.input(
+            placeholder=AuthState.t["matrix_search_placeholder"],
+            value=VoteMatrixState.inputed_value,
+            on_change=VoteMatrixState.set_search.debounce(300),
+            size="2",
+            style={"flex": "1 1 auto", "minWidth": "200px", "maxWidth": "320px"},
+        ),
+        rx.hstack(
+            rx.text(AuthState.t["matrix_status_label"], size="2", color="var(--gray-11)"),
+            rx.select.root(
+                rx.select.trigger(),
+                rx.select.content(
+                    rx.select.item(AuthState.t["gov_status_active"],   value="active"),
+                    rx.select.item(AuthState.t["gov_status_ratified"], value="ratified"),
+                    rx.select.item(AuthState.t["gov_status_enacted"],  value="enacted"),
+                    rx.select.item(AuthState.t["gov_status_dropped"],  value="dropped"),
+                    rx.select.item(AuthState.t["gov_status_expired"],  value="expired"),
+                ),
+                value=VoteMatrixState.ga_status,
+                on_change=VoteMatrixState.set_ga_status,
+                size="2",
+            ),
+            spacing="2",
+            align="center",
+        ),
+        rx.spacer(),
+        rx.hstack(
+            rx.text(AuthState.t["matrix_gas_per_page"], size="2", color="var(--gray-11)"),
+            rx.select(
+                _GA_PER_PAGE_OPTIONS,
+                value=VoteMatrixState.gas_per_page.to_string(),
+                on_change=VoteMatrixState.set_gas_per_page,
+                size="2",
+            ),
+            spacing="2",
+            align="center",
+        ),
+        rx.hstack(
+            rx.text(AuthState.t["matrix_per_page"], size="2", color="var(--gray-11)"),
+            rx.select(
+                _PER_PAGE_OPTIONS,
+                value=VoteMatrixState.items_per_page.to_string(),
+                on_change=VoteMatrixState.set_per_page,
+                size="2",
+            ),
+            spacing="2",
+            align="center",
+        ),
+        spacing="3",
+        align="center",
+        width="100%",
+        padding_y="8px",
+        wrap="wrap",
+    )
+
+
+def _ga_header_cell(ga) -> rx.Component:
+    """1 GA の header (上 1 行に sticky 配置)。タイトル truncate + クリックで詳細へ。"""
+    title_text = rx.cond(
+        AuthState.language == "ja",
+        rx.cond(ga["title_ja"] != "", ga["title_ja"], ga["title"]),
+        ga["title"],
+    )
+    fallback = rx.cond(ga["title"] != "", ga["title"], ga["proposal_id"])
+    display = rx.cond(title_text != "", title_text, fallback)
+    return rx.el.th(
+        rx.link(
+            rx.text(
+                display,
+                size="1",
+                weight="medium",
+                style={
+                    "display":          "-webkit-box",
+                    "WebkitLineClamp":  "2",
+                    "WebkitBoxOrient":  "vertical",
+                    "overflow":         "hidden",
+                    "lineHeight":       "1.3",
+                    "color":            "var(--gray-12)",
+                },
+            ),
+            rx.text(
+                ga["proposal_type"],
+                size="1",
+                style={"fontSize": "10px", "color": "var(--gray-9)"},
+            ),
+            href="/governance/" + ga["proposal_id"],
+            color="inherit",
+            underline="none",
+            style={"display": "block"},
+            title=display,
+        ),
+        style={
+            "position":     "sticky",
+            "top":          0,
+            "zIndex":       2,
+            "background":   "var(--gray-2)",
+            "padding":      "8px 10px",
+            "minWidth":     "140px",
+            "maxWidth":     "180px",
+            "borderBottom": "1px solid var(--gray-6)",
+            "borderRight":  "1px solid var(--gray-5)",
+            "verticalAlign": "top",
+            "textAlign":    "left",
+        },
+    )
+
+
+def _drep_name_cell(row) -> rx.Component:
+    """先頭列 (DRep 名 + アバター)、左 sticky。"""
+    return rx.el.td(
+        rx.hstack(
+            rx.cond(
+                row["image_url"] != "",
+                rx.image(
+                    src=row["image_url"],
+                    width="24px", height="24px",
+                    border_radius="50%",
+                    style={"objectFit": "cover", "flexShrink": "0"},
+                ),
+                rx.center(
+                    rx.icon("user-round", size=14, color="var(--gray-9)"),
+                    width="24px", height="24px",
+                    border_radius="50%",
+                    background="var(--gray-4)",
+                    style={"flexShrink": "0"},
+                ),
+            ),
+            rx.vstack(
+                rx.cond(
+                    row["given_name"] != "",
+                    rx.text(
+                        row["given_name"],
+                        size="2",
+                        weight="medium",
+                        color="var(--gray-12)",
+                        style={
+                            "whiteSpace":    "nowrap",
+                            "overflow":      "hidden",
+                            "textOverflow":  "ellipsis",
+                            "maxWidth":      "180px",
+                        },
+                    ),
+                    rx.text(
+                        AuthState.t["drep_no_name"],
+                        size="2",
+                        color="var(--gray-10)",
+                    ),
+                ),
+                rx.text(
+                    row["drep_id_short"],
+                    size="1",
+                    style={
+                        "fontFamily": "ui-monospace, monospace",
+                        "fontSize":   "10px",
+                        "color":      "var(--gray-10)",
+                    },
+                ),
+                spacing="0",
+                align_items="start",
+                style={"minWidth": "0"},
+            ),
+            spacing="2",
+            align="center",
+        ),
+        style={
+            "position":     "sticky",
+            "left":         0,
+            "background":   "var(--gray-1)",
+            "zIndex":       1,
+            "padding":      "8px 12px",
+            "borderRight":  "1px solid var(--gray-6)",
+            "borderBottom": "1px solid var(--gray-5)",
+            "minWidth":     "220px",
+            "maxWidth":     "240px",
+        },
+    )
+
+
+def _vote_cell(c) -> rx.Component:
+    tip = rx.cond(
+        AuthState.language == "ja",
+        rx.cond(c["rationale_ja"] != "", c["rationale_ja"], c["rationale"]),
+        c["rationale"],
+    )
+    badge = rx.match(
+        c["vote"],
+        ("yes",     rx.badge("Yes", color_scheme="green", variant="solid", size="1", radius="small")),
+        ("no",      rx.badge("No",  color_scheme="red",   variant="solid", size="1", radius="small")),
+        ("abstain", rx.badge("×",   color_scheme="gray",  variant="solid", size="1", radius="small")),
+        rx.text("—", style={
+            "color":      "var(--gray-9)",
+            "fontSize":   "14px",
+            "fontWeight": "600",
+        }),
+    )
+    return rx.el.td(
+        badge,
+        title=tip,
+        style={
+            "padding":       "8px",
+            "textAlign":     "center",
+            "verticalAlign": "middle",
+            "borderBottom":  "1px solid var(--gray-5)",
+            "borderRight":   "1px solid var(--gray-5)",
+            "minWidth":      "70px",
+            "background":    "var(--gray-1)",
+        },
+    )
+
+
+def _matrix_row(row) -> rx.Component:
+    return rx.el.tr(
+        _drep_name_cell(row),
+        rx.foreach(row["cells"], _vote_cell),
+    )
+
+
+def _matrix_table() -> rx.Component:
+    """投票マトリクス本体。左 1 列 / 上 1 行 sticky でスクロール対応。"""
+    return rx.cond(
+        VoteMatrixState.matrix_rows.length() == 0,
+        rx.center(
+            rx.text(AuthState.t["matrix_empty"], size="3", color="var(--gray-10)"),
+            padding_y="40px",
+            width="100%",
+            border="1px solid var(--gray-6)",
+            border_radius="10px",
+        ),
+        rx.box(
+            rx.el.table(
+                rx.el.thead(
+                    rx.el.tr(
+                        rx.el.th(
+                            rx.text(
+                                AuthState.t["matrix_col_drep"],
+                                size="2",
+                                weight="bold",
+                                color="var(--gray-12)",
+                            ),
+                            style={
+                                "position":     "sticky",
+                                "top":          0,
+                                "left":         0,
+                                "zIndex":       3,
+                                "background":   "var(--gray-2)",
+                                "padding":      "8px 12px",
+                                "borderBottom": "1px solid var(--gray-6)",
+                                "borderRight":  "1px solid var(--gray-6)",
+                                "minWidth":     "220px",
+                                "textAlign":    "left",
+                            },
+                        ),
+                        rx.foreach(VoteMatrixState.gas, _ga_header_cell),
+                    ),
+                ),
+                rx.el.tbody(
+                    rx.foreach(VoteMatrixState.matrix_rows, _matrix_row),
+                ),
+                style={
+                    "borderCollapse": "separate",
+                    "borderSpacing":  0,
+                    "width":          "max-content",
+                },
+            ),
+            style={
+                "overflow":      "auto",
+                "maxHeight":     "calc(100vh - 280px)",
+                "border":        "1px solid var(--gray-6)",
+                "borderRadius":  "10px",
+                "background":    "var(--gray-1)",
+                "width":         "100%",
+                "maxWidth":      "100%",
+                "minWidth":      "0",
+                "alignSelf":     "stretch",
+            },
+        ),
+    )
+
+
+def _legend() -> rx.Component:
+    """凡例: 投票結果のバッジ説明。"""
+    def _item(badge: rx.Component, label_key: str):
+        return rx.hstack(
+            badge,
+            rx.text(AuthState.t[label_key], size="1", color="var(--gray-11)"),
+            spacing="1",
+            align="center",
+        )
+
+    return rx.flex(
+        _item(rx.badge("Yes", color_scheme="green", variant="solid", size="1", radius="small"),
+              "matrix_legend_yes"),
+        _item(rx.badge("No",  color_scheme="red",   variant="solid", size="1", radius="small"),
+              "matrix_legend_no"),
+        _item(rx.badge("×",   color_scheme="gray",  variant="solid", size="1", radius="small"),
+              "matrix_legend_abstain"),
+        _item(rx.text("—", style={"color": "var(--gray-9)", "fontWeight": "600"}),
+              "matrix_legend_no_vote"),
+        spacing="4",
+        wrap="wrap",
+        align="center",
+        padding_y="4px",
+    )
+
+
+def _pagination() -> rx.Component:
+    """DRep 行のページネーション。"""
+    def btn(page):
+        is_active = page == VoteMatrixState.current_page
+        return rx.button(
+            rx.text(page, weight="bold"),
+            on_click=lambda: VoteMatrixState.set_page(page),
+            variant=rx.cond(is_active, "solid", "soft"),
+            radius="full",
+            size="2",
+            padding_x="10px",
+            class_name="md:inline-flex hidden",
+            _hover={"cursor": "pointer"},
+        )
+    return rx.flex(
+        rx.button(
+            rx.icon(tag="chevron-left"),
+            on_click=VoteMatrixState.prev_page,
+            radius="full",
+            size="2",
+            variant="soft",
+            disabled=VoteMatrixState.current_page == 1,
+            _hover={"cursor": "pointer"},
+        ),
+        rx.foreach(VoteMatrixState.middle_page, btn),
+        rx.button(
+            rx.icon(tag="chevron-right"),
+            on_click=VoteMatrixState.next_page,
+            radius="full",
+            size="2",
+            variant="soft",
+            disabled=VoteMatrixState.current_page == VoteMatrixState.total_pages,
+            _hover={"cursor": "pointer"},
+        ),
+        class_name="pagination gap-2",
+        padding_top="1.5em",
+        justify="end",
+        align="center",
+    )
+
+
+def _gas_pagination() -> rx.Component:
+    """GA 列のページネーション (マトリクス上部に表示)。"""
+    def btn(page):
+        is_active = page == VoteMatrixState.gas_current_page
+        return rx.button(
+            rx.text(page, weight="bold"),
+            on_click=lambda: VoteMatrixState.set_gas_page(page),
+            variant=rx.cond(is_active, "solid", "soft"),
+            radius="full",
+            size="1",
+            padding_x="8px",
+            class_name="md:inline-flex hidden",
+            _hover={"cursor": "pointer"},
+        )
+    return rx.flex(
+        rx.text(
+            AuthState.t["matrix_gas_total"], " ",
+            VoteMatrixState.gas_total_items.to_string(),
+            size="1", color="var(--gray-10)",
+        ),
+        rx.spacer(),
+        rx.button(
+            rx.icon(tag="chevron-left", size=14),
+            on_click=VoteMatrixState.prev_gas_page,
+            radius="full",
+            size="1",
+            variant="soft",
+            disabled=VoteMatrixState.gas_current_page == 1,
+            _hover={"cursor": "pointer"},
+        ),
+        rx.foreach(VoteMatrixState.gas_middle_page, btn),
+        rx.button(
+            rx.icon(tag="chevron-right", size=14),
+            on_click=VoteMatrixState.next_gas_page,
+            radius="full",
+            size="1",
+            variant="soft",
+            disabled=VoteMatrixState.gas_current_page == VoteMatrixState.gas_total_pages,
+            _hover={"cursor": "pointer"},
+        ),
+        class_name="gas-pagination gap-1",
+        padding_y="6px",
+        align="center",
+        width="100%",
+    )
+
+
+# ─── Page ─────────────────────────────────────────────────────────────────────
+
+
+@template(
+    route="/governance/matrix",
+    title="投票マトリクス | ガバナンス | Cardanoism",
+    on_load=VoteMatrixState.on_load,
+)
+def governance_matrix_page() -> rx.Component:
+    return rx.cond(
+        VoteMatrixState.load,
+        rx.box(
+            rx.vstack(
+                _breadcrumb(),
+                governance_subnav("matrix"),
+                rx.heading(
+                    AuthState.t["matrix_title"],
+                    size="6",
+                    weight="bold",
+                    style={"marginTop": "8px"},
+                ),
+                rx.text(
+                    AuthState.t["matrix_desc"],
+                    size="2",
+                    color="var(--gray-10)",
+                ),
+                _filter_bar(),
+                _legend(),
+                rx.cond(
+                    VoteMatrixState.error != "",
+                    rx.callout(
+                        VoteMatrixState.error,
+                        icon="triangle-alert",
+                        color_scheme="red",
+                        size="1",
+                    ),
+                    rx.fragment(),
+                ),
+                _gas_pagination(),
+                _matrix_table(),
+                rx.hstack(
+                    rx.text(
+                        AuthState.t["matrix_total"], " ",
+                        VoteMatrixState.total_items.to_string(),
+                        size="2",
+                        color="var(--gray-10)",
+                    ),
+                    rx.spacer(),
+                    _pagination(),
+                    align="center",
+                    width="100%",
+                ),
+                spacing="3",
+                max_width="1480px",
+                margin_x="auto",
+                width="100%",
+                padding_x="20px",
+                padding_bottom="40px",
+            ),
+        ),
+        rx.flex(
+            rx.spinner(size="3"),
+            justify="center",
+            align="center",
+            width="100%",
+            padding_y="40px",
+        ),
+    )

--- a/cardanoism/pages/index.py
+++ b/cardanoism/pages/index.py
@@ -18,12 +18,15 @@ ACCENT_DARK = "#c7a300"
 TEXT_MUTED = "var(--gray-10)"
 
 # 機能ごとのアクセントカラー
-F_AI    = "#7c5cff"   # 紫: AI
-F_DREP  = "#3b82f6"   # 青: DRep
-F_CONST = "#0ea5e9"   # 水色: 憲法
-F_TRES  = "#16a34a"   # 緑: トレジャリー
-F_NOTI  = "#f97316"   # オレンジ: 通知
-F_GA    = "#ec4899"   # ピンク: GA 日本語化
+F_AI     = "#7c5cff"   # 紫: AI 提案要約 + 投票マトリクス
+F_WALLET = "#10b981"   # エメラルド: ウォレット連携
+F_CAT    = "#eab308"   # 黄: Catalyst
+F_CONST  = "#0ea5e9"   # 水色: 憲法
+F_TRES   = "#16a34a"   # 緑: トレジャリー
+F_NOTI   = "#f97316"   # オレンジ: ステーキング通知
+# 旧カード用 (mock 関数で参照され続けている)
+F_DREP   = "#3b82f6"   # 青: DRep
+F_GA     = "#ec4899"   # ピンク: GA 日本語化
 F_BLK   = "#e11d48"   # 赤: ライブブロック
 
 LINE_BRAND = "#06C755"
@@ -682,6 +685,27 @@ def _mock_notify() -> rx.Component:
     )
 
 
+def _mock_wallet() -> rx.Component:
+    """ウォレット連携 mock。主要 Cardano ウォレット名のチップ。"""
+    return rx.hstack(
+        _mock_chip("Eternl", F_WALLET),
+        _mock_chip("Lace",   F_WALLET),
+        _mock_chip("Nami",   F_WALLET),
+        _mock_chip("Yoroi",  F_WALLET),
+        spacing="1", wrap="wrap",
+    )
+
+
+def _mock_catalyst() -> rx.Component:
+    """Catalyst 管理 mock。Fund 番号とステータスのチップ。"""
+    return rx.hstack(
+        _mock_chip("Fund 12", F_CAT),
+        _mock_chip("Fund 13", F_CAT),
+        _mock_chip("Fund 14", F_CAT),
+        spacing="1", wrap="wrap",
+    )
+
+
 def _mock_ga_ja() -> rx.Component:
     """GA 日本語化を表すミニ mock。EN→JA バッジ + サンプルタイトル。"""
     return rx.vstack(
@@ -720,7 +744,7 @@ def features_section() -> rx.Component:
                 AuthState.t["home_features_subtitle"],
             ),
             rx.grid(
-                # 1. リアルタイム通知
+                # 1. ステーキング報酬・プール状態の即時通知
                 _feature_card(
                     "bell", F_NOTI,
                     AuthState.t["home_f_notify_title"],
@@ -728,31 +752,31 @@ def features_section() -> rx.Component:
                     href="/mypage?tab=notification",
                     mock=_mock_notify(),
                 ),
-                # 2. ガバナンスアクション日本語化
+                # 2. ウォレット連携で委任完結
                 _feature_card(
-                    "languages", F_GA,
-                    AuthState.t["home_f_ga_title"],
-                    AuthState.t["home_f_ga_desc"],
-                    href="/governance",
-                    mock=_mock_ga_ja(),
+                    "wallet", F_WALLET,
+                    AuthState.t["home_f_wallet_title"],
+                    AuthState.t["home_f_wallet_desc"],
+                    href="/staking",
+                    mock=_mock_wallet(),
                 ),
-                # 3. AI による提案概要整理
+                # 3. AI 提案要約 + 投票マトリクス
                 _feature_card(
                     "sparkles", F_AI,
                     AuthState.t["home_f_ai_title"],
                     AuthState.t["home_f_ai_desc"],
-                    href="/governance",
+                    href="/governance/matrix",
                     mock=_mock_ai(),
                 ),
-                # 4. 委任先 DRep 投票表示
+                # 4. Catalyst 提案管理
                 _feature_card(
-                    "user-check", F_DREP,
-                    AuthState.t["home_f_drep_title"],
-                    AuthState.t["home_f_drep_desc"],
-                    href="/governance",
-                    mock=_mock_drep(),
+                    "list-checks", F_CAT,
+                    AuthState.t["home_f_catalyst_title"],
+                    AuthState.t["home_f_catalyst_desc"],
+                    href="/catalyst",
+                    mock=_mock_catalyst(),
                 ),
-                # 5. トレジャリー残高シミュレーション
+                # 5. トレジャリー残高グラフ
                 _feature_card(
                     "trending-up", F_TRES,
                     AuthState.t["home_f_treasury_title"],


### PR DESCRIPTION
新ページ /governance/matrix:
- 横軸 GA / 縦軸 DRep のマトリクス。Yes/No/× バッジで投票結果を一目で把握、 マウスオーバーで投票理由 (rationale_ja / rationale) を表示
- ステータスフィルタ (active / ratified / enacted / dropped / expired)
- DRep / GA とも 20-100 件のページネーション対応 (廃止/失効が大量でも軽量)
- 上 1 行 / 左 1 列 sticky でスクロール時に見出しを保持
- DRep 名検索ボックス
- グローバルナビとサブナビに「投票マトリクス」をガバナンス提案の右隣に追加

新 DB ヘルパー cardanoism/backend/vote_matrix_db.py:
- get_gas_for_matrix / count_gas_for_matrix / get_dreps_for_matrix / count_dreps_for_matrix / get_votes_for_matrix

TOP の Feature Showcase を再構成:
- 「ガバナンス参加を加速する 6 つの機能」→「カルダノ参加を身近にする 6 つの機能」
- ガバナンス比率 5/6 → 3/6 に縮減し、ステーキング通知・ウォレット連携・Catalyst を 全面に押し出す。GA 日本語化と DRep 投票表示カードはマトリクス機能 + AI カードに集約