### PR TITLE
feat: 投票マトリクス + ステーキング啓発ページ + モバイル UX 改善

### DIFF
--- a/cardanoism/backend/auth_state.py
+++ b/cardanoism/backend/auth_state.py
@@ -780,13 +780,17 @@ class AuthState(rx.State):
     # ログアウト
     # ============================================================
 
-    def logout(self):
-        if self.session_token:
-            try:
-                delete_session(self.session_token)
-            except Exception as e:
-                logger.warning("Failed to delete session: %s", e)
+    @rx.event(background=True)
+    async def delete_session_async(self, token: str):
+        """セッション DB 削除をバックグラウンドで実行 (logout の体感速度向上)。"""
+        try:
+            delete_session(token)
+        except Exception as e:
+            logger.warning("Failed to delete session async: %s", e)
 
+    def logout(self):
+        # 1) State をまず即座にクリアして UI をログアウト状態に
+        token = self.session_token
         self.session_token = ""
         self.is_logged_in = False
         self.user_id = 0
@@ -801,7 +805,14 @@ class AuthState(rx.State):
         self.favorites = []
         self.ga_favorite_ids = []
         self.ga_favorites = []
-        return rx.redirect("/")
+
+        # 2) DB 削除はバックグラウンド (ネットワーク往復で UI を待たせない)
+        events: list = []
+        if token:
+            events.append(AuthState.delete_session_async(token))
+        # 3) 即座にホームへリダイレクト
+        events.append(rx.redirect("/"))
+        return events
 
     # ============================================================
     # プロフィール編集

--- a/cardanoism/components/navbar.py
+++ b/cardanoism/components/navbar.py
@@ -325,7 +325,13 @@ def navbar_icons() -> rx.Component:
         rx.hstack(
             logo,
             rx.hstack(
-                auth_section(),
+                # ログイン済みのみアバターを表示。未ログインのログインボタンは
+                # 三本線メニュー内 (バッジ) に集約してトップバーをスッキリさせる。
+                rx.cond(
+                    AuthState.is_logged_in,
+                    auth_section(),
+                    rx.fragment(),
+                ),
                 rx.menu.root(
                     rx.menu.trigger(
                         rx.box(
@@ -360,7 +366,28 @@ def navbar_icons() -> rx.Component:
                                 rx.menu.item(rx.link(AuthState.t["nav_mypage"], href="/mypage", width="100%", underline="none", color="var(--gray-12)")),
                                 rx.menu.item(rx.text(AuthState.t["nav_logout"], size="3", color="var(--red-9)", on_click=AuthState.logout, cursor="pointer", width="100%")),
                             ),
-                            rx.menu.item(rx.link(AuthState.t["nav_login"], href="/login", width="100%", underline="none", color="var(--gray-12)")),
+                            rx.menu.item(
+                                rx.link(
+                                    rx.box(
+                                        rx.text(
+                                            AuthState.t["nav_login"],
+                                            size="2",
+                                            weight="bold",
+                                            style={"color": "#111"},
+                                        ),
+                                        padding="6px 16px",
+                                        border_radius="9999px",
+                                        style={
+                                            "background": f"linear-gradient(135deg, {ACCENT}, {ACCENT_DARK})",
+                                            "display": "inline-flex",
+                                            "alignItems": "center",
+                                            "boxShadow": "0 2px 8px rgba(255,207,0,0.35)",
+                                        },
+                                    ),
+                                    href="/login",
+                                    underline="none",
+                                ),
+                            ),
                         ),
                     ),
                 ),

--- a/cardanoism/pages/index.py
+++ b/cardanoism/pages/index.py
@@ -727,12 +727,15 @@ def features_section() -> rx.Component:
 
 def constitution_highlight_section() -> rx.Component:
     def _version_badge() -> rx.Component:
-        # 関数で都度生成して、複数箇所で安全に再利用できるようにする
         return rx.cond(
             HomeState.constitution_version_label != "",
             rx.box(
-                rx.text(HomeState.constitution_version_label, size="2", weight="bold", color="white"),
-                padding="4px 14px",
+                rx.text(
+                    HomeState.constitution_version_label,
+                    size="1", weight="bold", color="white",
+                    style={"whiteSpace": "nowrap"},
+                ),
+                padding="4px 12px",
                 border_radius="999px",
                 background=F_CONST,
                 style={"flexShrink": "0"},
@@ -740,135 +743,135 @@ def constitution_highlight_section() -> rx.Component:
             rx.fragment(),
         )
 
+    # 左カラム: 啓発コンテンツ
+    left_col = rx.vstack(
+        rx.text(
+            AuthState.t["home_constitution_kicker"],
+            size="1", weight="bold", color=F_CONST, letter_spacing="0.18em",
+        ),
+        rx.heading(
+            AuthState.t["home_constitution_title"],
+            as_="h2",
+            size={"base": "5", "sm": "6", "md": "7"},
+            weight="bold",
+            line_height="1.25",
+            style={"wordBreak": "break-word", "overflowWrap": "anywhere", "maxWidth": "100%"},
+        ),
+        rx.text(
+            AuthState.t["home_constitution_subtitle"],
+            size={"base": "2", "md": "3"},
+            color=TEXT_MUTED, line_height="1.75",
+            style={"wordBreak": "break-word", "maxWidth": "100%"},
+        ),
+        rx.flex(
+            rx.text(
+                AuthState.t["home_constitution_version_label"],
+                size="2", color=TEXT_MUTED,
+            ),
+            _version_badge(),
+            spacing="2",
+            align="center",
+            wrap="wrap",
+        ),
+        rx.link(
+            rx.button(
+                rx.icon("scroll-text", size=16),
+                AuthState.t["home_constitution_cta"],
+                rx.icon("arrow-right", size=16),
+                size="3",
+                background=F_CONST,
+                color="white",
+                cursor="pointer",
+                padding="0 22px",
+                _hover={"background": "#0284c7"},
+                style={"boxShadow": f"0 12px 32px -10px {F_CONST}"},
+            ),
+            href="/governance/constitution",
+            underline="none",
+        ),
+        spacing="4",
+        align_items="start",
+        width="100%",
+        style={"minWidth": "0", "flex": "1 1 50%"},
+    )
+
+    # 右カラム: 憲法プレビューカード
+    preview_card = rx.box(
+        rx.vstack(
+            rx.flex(
+                rx.icon("scroll-text", size=18, color=F_CONST),
+                rx.text(
+                    AuthState.t["home_constitution_preview_doc_title"],
+                    size="2", weight="bold", color="var(--gray-12)",
+                    style={"flex": "1 1 auto", "minWidth": "0"},
+                ),
+                _version_badge(),
+                spacing="2",
+                align="center",
+                width="100%",
+                wrap="wrap",
+            ),
+            rx.divider(),
+            rx.text(
+                AuthState.t["home_constitution_preview_article_en"],
+                size="2", weight="bold", color="var(--gray-12)",
+            ),
+            rx.text(
+                AuthState.t["home_constitution_preview_quote_en"],
+                size="1", color=TEXT_MUTED, line_height="1.6",
+                style={"fontStyle": "italic", "wordBreak": "break-word"},
+            ),
+            rx.text(
+                AuthState.t["home_constitution_preview_article_ja"],
+                size="2", weight="bold", color="var(--gray-12)",
+                style={"marginTop": "8px"},
+            ),
+            rx.text(
+                AuthState.t["home_constitution_preview_quote_ja"],
+                size="1", color=TEXT_MUTED, line_height="1.6",
+                style={"wordBreak": "break-word"},
+            ),
+            spacing="2",
+            align_items="start",
+            width="100%",
+        ),
+        padding=["18px", "20px", "22px"],
+        border=f"1px solid {F_CONST}33",
+        border_radius="16px",
+        background=rx.color_mode_cond(
+            "rgba(255,255,255,0.95)", "rgba(255,255,255,0.04)",
+        ),
+        backdrop_filter="blur(10px)",
+        box_shadow=f"0 22px 60px -28px {F_CONST}55",
+        width="100%",
+        style={
+            "minWidth": "0",
+            "flex": "1 1 50%",
+            "boxSizing": "border-box",
+        },
+    )
+
     return rx.box(
         _shell(
             rx.flex(
-                rx.vstack(
-                    rx.text(
-                        AuthState.t["home_constitution_kicker"],
-                        size="1", weight="bold", color=F_CONST, letter_spacing="0.18em",
-                    ),
-                    rx.heading(
-                        AuthState.t["home_constitution_title"],
-                        as_="h2",
-                        size={"base": "6", "md": "7"},
-                        weight="bold",
-                        line_height="1.25",
-                        max_width="640px",
-                        style={"wordBreak": "break-word", "overflowWrap": "anywhere"},
-                    ),
-                    rx.text(
-                        AuthState.t["home_constitution_subtitle"],
-                        size="3", color=TEXT_MUTED, line_height="1.75",
-                        max_width="600px",
-                        style={"wordBreak": "break-word"},
-                    ),
-                    rx.flex(
-                        rx.text(
-                            AuthState.t["home_constitution_version_label"],
-                            size="2", color=TEXT_MUTED,
-                        ),
-                        _version_badge(),
-                        spacing="2",
-                        align="center",
-                        wrap="wrap",
-                    ),
-                    rx.link(
-                        rx.button(
-                            rx.icon("scroll-text", size=16),
-                            AuthState.t["home_constitution_cta"],
-                            rx.icon("arrow-right", size=16),
-                            size="3",
-                            background=F_CONST,
-                            color="white",
-                            cursor="pointer",
-                            padding="0 22px",
-                            _hover={"background": "#0284c7"},
-                            style={"boxShadow": f"0 12px 32px -10px {F_CONST}"},
-                        ),
-                        href="/governance/constitution",
-                        underline="none",
-                    ),
-                    spacing="4",
-                    align_items="start",
-                    flex="1",
-                    width="100%",
-                    min_width="0",
-                ),
-                rx.box(
-                    rx.box(
-                        rx.vstack(
-                            rx.flex(
-                                rx.icon("scroll-text", size=18, color=F_CONST),
-                                rx.text(
-                                    AuthState.t["home_constitution_preview_doc_title"],
-                                    size="2", weight="bold", color="var(--gray-12)",
-                                    style={
-                                        "minWidth": "0",
-                                        "overflow": "hidden",
-                                        "textOverflow": "ellipsis",
-                                        "whiteSpace": "nowrap",
-                                    },
-                                ),
-                                rx.spacer(),
-                                _version_badge(),
-                                spacing="2",
-                                align="center",
-                                width="100%",
-                                wrap="wrap",
-                            ),
-                            rx.divider(),
-                            # 英語原文ブロック
-                            rx.text(
-                                AuthState.t["home_constitution_preview_article_en"],
-                                size="2", weight="bold", color="var(--gray-12)",
-                            ),
-                            rx.text(
-                                AuthState.t["home_constitution_preview_quote_en"],
-                                size="1", color=TEXT_MUTED, line_height="1.6",
-                                style={"fontStyle": "italic"},
-                            ),
-                            # 日本語訳ブロック
-                            rx.text(
-                                AuthState.t["home_constitution_preview_article_ja"],
-                                size="2", weight="bold", color="var(--gray-12)",
-                                style={"marginTop": "8px"},
-                            ),
-                            rx.text(
-                                AuthState.t["home_constitution_preview_quote_ja"],
-                                size="1", color=TEXT_MUTED, line_height="1.6",
-                            ),
-                            spacing="2", align_items="start",
-                        ),
-                        padding="20px 22px",
-                        border=f"1px solid {F_CONST}33",
-                        border_radius="16px",
-                        background=rx.color_mode_cond(
-                            "rgba(255,255,255,0.95)", "rgba(255,255,255,0.04)",
-                        ),
-                        backdrop_filter="blur(10px)",
-                        box_shadow=f"0 22px 60px -28px {F_CONST}55",
-                    ),
-                    flex="0 0 auto",
-                    width=["100%", "100%", "420px"],
-                    style={"animation": "cdn_float 8s ease-in-out infinite"},
-                ),
+                left_col,
+                preview_card,
                 direction={"base": "column", "md": "row"},
-                align="center",
-                spacing="8",
+                align={"base": "stretch", "md": "center"},
+                spacing={"base": "5", "md": "8"},
                 width="100%",
+                style={"minWidth": "0"},
             ),
-            padding_y=["48px", "60px", "76px"],
+            padding_y=["40px", "52px", "72px"],
         ),
         background=rx.color_mode_cond(
             "linear-gradient(135deg, #f0f9ff 0%, #ecfeff 100%)",
             "linear-gradient(135deg, #0c1422 0%, #0a1820 100%)",
         ),
-        width="100vw",
-        margin_left="calc(-50vw + 50%)",
-        margin_right="calc(-50vw + 50%)",
+        width="100%",
         border_top=f"1px solid {rx.color('gray', 4)}",
         border_bottom=f"1px solid {rx.color('gray', 4)}",
+        style={"overflow": "hidden"},
     )
 
 


### PR DESCRIPTION
## Summary

### 新ページ
- **`/governance/matrix`** — DRep × GA 投票マトリクス
  - Yes/No/× の solid バッジ表示、マウスオーバーで投票理由ツールチップ
  - ステータスフィルタ (active / ratified / enacted / dropped / expired)
  - DRep 行 / GA 列 両方ページネーション (20/30/50/100)
  - 行 hover ハイライト、DRep 名から個別ページへリンク
  - sticky ヘッダー + 横スクロール、モバイルで DRep 列を狭く調整
- **`/staking/why`** — ステーキング初心者向け啓発ページ
  - ヒーロー「委任して報酬をもらう、それだけ」+ 自己管理 / ロックなし / いつでも解除
  - 4 ステップで始める / プール選び 3 つのコツ / 報酬タイムライン / FAQ / CTA

### ナビゲーション
- グローバルナビ並び: ホーム → ステーキング → ガバナンス → カタリスト → マイページ
- staking サブナビに「ステーキングとは？」追加
- governance サブナビに「投票マトリクス」追加
- カタリストの「ラウンド」を「ファンド」に修正

### TOP リニューアル
- LIVE NETWORK セクション削除、FEATURES に集中
- 機能カードを再構成: ステーキング 2 / ガバナンス 3 / Catalyst 1
- ヒーロー CTA を「ステークプールをチェック」に変更