### PR TITLE
refactor(ui): breadcrumb / subnav pill を共通コンポーネント化

### DIFF
--- a/cardanoism/components/breadcrumb.py
+++ b/cardanoism/components/breadcrumb.py
@@ -1,0 +1,51 @@
+"""breadcrumb.py
+パンくずリストの共通コンポーネント。
+
+各ページの `_breadcrumb()` 関数が
+「home icon → chevron → 中間リンク群 → chevron → 現在地テキスト」
+の同型コピペになっていたため集約。
+
+Usage:
+    breadcrumb([
+        ("nav_governance", "/governance"),     # 中間リンク (i18n key, href)
+    ], current_key="gov_subnav_why")           # 現在地 (i18n key)
+
+home (`/`) は自動で先頭に挿入される。
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+import reflex as rx
+
+from cardanoism.backend.auth_state import AuthState
+
+
+def _chevron() -> rx.Component:
+    return rx.icon("chevron-right", size=14, color="gray")
+
+
+def breadcrumb(intermediate: Iterable[tuple[str, str]], current_key: str) -> rx.Component:
+    """home → 中間リンク群 → 現在地 のパンくずを生成する。
+
+    Args:
+        intermediate: (i18n_key, href) の列。中間リンク群。
+        current_key:  現在地として表示する i18n key (リンクではないテキスト)。
+    """
+    children: list[rx.Component] = [
+        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
+    ]
+    for key, href in intermediate:
+        children.append(_chevron())
+        children.append(
+            rx.link(
+                AuthState.t[key], href=href,
+                size="2", underline="hover", color_scheme="gray",
+            )
+        )
+    children.append(_chevron())
+    children.append(rx.text(AuthState.t[current_key], size="2", weight="medium"))
+    return rx.hstack(
+        *children,
+        spacing="2", align="center", width="100%", padding_top="15px",
+    )

--- a/cardanoism/components/governance_nav.py
+++ b/cardanoism/components/governance_nav.py
@@ -1,51 +1,12 @@
 """
 governance_nav.py
-ガバナンス配下のサブページ（アクション一覧 / DRep / トレジャリー）を横移動するピル型ナビゲーション
+ガバナンス配下のサブページ（アクション一覧 / DRep / トレジャリー / 投票マトリクス / 憲法）を
+横移動するピル型ナビゲーション。
 """
 import reflex as rx
 
 from cardanoism.backend.auth_state import AuthState
-
-
-def _pill(label, href: str, icon_name: str, active: bool) -> rx.Component:
-    base = {
-        "display": "inline-flex",
-        "alignItems": "center",
-        "gap": "6px",
-        "padding": "6px 14px",
-        "borderRadius": "9999px",
-        "fontSize": "14px",
-        "fontWeight": "600",
-        "textDecoration": "none",
-        "border": "1px solid transparent",
-        "transition": "background 0.15s, color 0.15s, border-color 0.15s",
-        "cursor": "pointer",
-    }
-    if active:
-        style = {
-            **base,
-            "background": "var(--amber-7)",
-            "color": "var(--gray-12)",
-            "border": "1px solid var(--amber-8)",
-        }
-    else:
-        style = {
-            **base,
-            "background": "var(--gray-3)",
-            "color": "var(--gray-11)",
-        }
-    return rx.link(
-        rx.icon(icon_name, size=14),
-        rx.text(label, size="2", weight="medium"),
-        href=href,
-        style=style,
-        _hover=None if active else {
-            "background": "var(--gray-4)",
-            "color": "var(--gray-12)",
-            "textDecoration": "none",
-        },
-        underline="none",
-    )
+from cardanoism.components.subnav_pill import pill_subnav
 
 
 def governance_subnav(active: str) -> rx.Component:
@@ -56,15 +17,11 @@ def governance_subnav(active: str) -> rx.Component:
 
     並び順: ガバナンスとは → ガバナンス提案 → 投票マトリクス → トレジャリー → DRep 一覧 → Cardano 憲法
     """
-    return rx.hstack(
-        _pill(AuthState.t["gov_subnav_why"], "/governance/why", "lightbulb", active == "why"),
-        _pill(AuthState.t["gov_subnav_actions"], "/governance", "gavel", active == "actions"),
-        _pill(AuthState.t["gov_subnav_matrix"], "/governance/matrix", "table-2", active == "matrix"),
-        _pill(AuthState.t["gov_subnav_treasury"], "/governance/treasury", "landmark", active == "treasury"),
-        _pill(AuthState.t["gov_subnav_drep"], "/governance/drep", "users", active == "drep"),
-        _pill(AuthState.t["gov_subnav_constitution"], "/governance/constitution", "scroll-text", active == "constitution"),
-        spacing="2",
-        wrap="wrap",
-        width="100%",
-        padding_y="8px",
-    )
+    return pill_subnav(active, [
+        ("why",          AuthState.t["gov_subnav_why"],          "/governance/why",          "lightbulb"),
+        ("actions",      AuthState.t["gov_subnav_actions"],      "/governance",              "gavel"),
+        ("matrix",       AuthState.t["gov_subnav_matrix"],       "/governance/matrix",       "table-2"),
+        ("treasury",     AuthState.t["gov_subnav_treasury"],     "/governance/treasury",     "landmark"),
+        ("drep",         AuthState.t["gov_subnav_drep"],         "/governance/drep",         "users"),
+        ("constitution", AuthState.t["gov_subnav_constitution"], "/governance/constitution", "scroll-text"),
+    ])

--- a/cardanoism/components/staking_nav.py
+++ b/cardanoism/components/staking_nav.py
@@ -1,52 +1,11 @@
 """
 staking_nav.py
 ステーキング配下のサブページ（ダッシュボード / SPO 一覧）を横移動するピル型ナビゲーション。
-governance_nav と同じ意匠で揃える。
 """
 import reflex as rx
 
 from cardanoism.backend.auth_state import AuthState
-
-
-def _pill(label, href: str, icon_name: str, active: bool) -> rx.Component:
-    base = {
-        "display": "inline-flex",
-        "alignItems": "center",
-        "gap": "6px",
-        "padding": "6px 14px",
-        "borderRadius": "9999px",
-        "fontSize": "14px",
-        "fontWeight": "600",
-        "textDecoration": "none",
-        "border": "1px solid transparent",
-        "transition": "background 0.15s, color 0.15s, border-color 0.15s",
-        "cursor": "pointer",
-    }
-    if active:
-        style = {
-            **base,
-            "background": "var(--amber-7)",
-            "color": "var(--gray-12)",
-            "border": "1px solid var(--amber-8)",
-        }
-    else:
-        style = {
-            **base,
-            "background": "var(--gray-3)",
-            "color": "var(--gray-11)",
-        }
-    return rx.link(
-        rx.icon(icon_name, size=14),
-        rx.text(label, size="2", weight="medium"),
-        href=href,
-        style=style,
-        _hover=None if active else {
-            "background": "var(--gray-4)",
-            "color": "var(--gray-12)",
-            "textDecoration": "none",
-        },
-        underline="none",
-    )
+from cardanoism.components.subnav_pill import pill_subnav
 
 
 def staking_subnav(active: str) -> rx.Component:
@@ -55,12 +14,8 @@ def staking_subnav(active: str) -> rx.Component:
     Args:
         active: 現在のタブ（"why" | "dashboard" | "spo"）
     """
-    return rx.hstack(
-        _pill(AuthState.t["staking_subnav_why"], "/staking/why", "lightbulb", active == "why"),
-        _pill(AuthState.t["staking_subnav_dashboard"], "/staking", "layout-dashboard", active == "dashboard"),
-        _pill(AuthState.t["staking_subnav_spo"], "/staking/spo", "server", active == "spo"),
-        spacing="2",
-        wrap="wrap",
-        width="100%",
-        padding_y="8px",
-    )
+    return pill_subnav(active, [
+        ("why",       AuthState.t["staking_subnav_why"],       "/staking/why",  "lightbulb"),
+        ("dashboard", AuthState.t["staking_subnav_dashboard"], "/staking",      "layout-dashboard"),
+        ("spo",       AuthState.t["staking_subnav_spo"],       "/staking/spo",  "server"),
+    ])

--- a/cardanoism/components/subnav_pill.py
+++ b/cardanoism/components/subnav_pill.py
@@ -1,0 +1,68 @@
+"""subnav_pill.py
+ピル型サブナビの共通描画ヘルパー。
+
+governance_nav / staking_nav が同じ意匠の `_pill()` を別々に持っていたため
+集約。新しいサブナビを追加するときは items リストだけ書けばよい。
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+import reflex as rx
+
+
+def _pill(label, href: str, icon_name: str, active: bool) -> rx.Component:
+    base = {
+        "display": "inline-flex",
+        "alignItems": "center",
+        "gap": "6px",
+        "padding": "6px 14px",
+        "borderRadius": "9999px",
+        "fontSize": "14px",
+        "fontWeight": "600",
+        "textDecoration": "none",
+        "border": "1px solid transparent",
+        "transition": "background 0.15s, color 0.15s, border-color 0.15s",
+        "cursor": "pointer",
+    }
+    if active:
+        style = {
+            **base,
+            "background": "var(--amber-7)",
+            "color": "var(--gray-12)",
+            "border": "1px solid var(--amber-8)",
+        }
+    else:
+        style = {
+            **base,
+            "background": "var(--gray-3)",
+            "color": "var(--gray-11)",
+        }
+    return rx.link(
+        rx.icon(icon_name, size=14),
+        rx.text(label, size="2", weight="medium"),
+        href=href,
+        style=style,
+        _hover=None if active else {
+            "background": "var(--gray-4)",
+            "color": "var(--gray-12)",
+            "textDecoration": "none",
+        },
+        underline="none",
+    )
+
+
+def pill_subnav(active: str, items: Iterable[tuple]) -> rx.Component:
+    """ピル型サブナビを描画する。
+
+    Args:
+        active: アクティブな key (各 item の最初の要素と一致するもの)
+        items: タプル (key, label, href, icon) のシーケンス
+    """
+    return rx.hstack(
+        *[_pill(label, href, icon, key == active) for key, label, href, icon in items],
+        spacing="2",
+        wrap="wrap",
+        width="100%",
+        padding_y="8px",
+    )

--- a/cardanoism/pages/governance_drep.py
+++ b/cardanoism/pages/governance_drep.py
@@ -19,6 +19,7 @@ from cardanoism.backend.drep_db import get_dreps, count_dreps, sum_total_delegat
 from cardanoism.backend.fiat_db import get_fiat_rate
 from cardanoism.backend.price import format_ada, format_jpy_short, format_usd_short
 from cardanoism.components.governance_nav import governance_subnav
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.login_modal import login_modal
 from cardanoism.components.drep_delegation_dialog import drep_delegation_dialog
 
@@ -160,17 +161,7 @@ class DrepState(rx.State):
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_governance"], href="/governance", size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["gov_subnav_drep"], size="2", weight="medium"),
-        spacing="2",
-        align="center",
-        width="100%",
-        padding_top="15px",
-    )
+    return breadcrumb([("nav_governance", "/governance")], "gov_subnav_drep")
 
 
 def _drep_card(d) -> rx.Component:

--- a/cardanoism/pages/governance_drep_detail.py
+++ b/cardanoism/pages/governance_drep_detail.py
@@ -17,6 +17,7 @@ from cardanoism.backend.drep_db import get_drep, sum_total_delegation
 from cardanoism.backend.vote_db import get_votes_by_drep, count_votes_by_drep
 from cardanoism.backend.fiat_db import get_fiat_rate
 from cardanoism.backend.price import format_ada, format_jpy_short, format_usd_short
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.governance_nav import governance_subnav
 from cardanoism.components.login_modal import login_modal
 from cardanoism.components.governance_card import _vote_badge
@@ -179,18 +180,9 @@ class DrepDetailState(rx.State):
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_governance"], href="/governance", size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["gov_subnav_drep"], href="/governance/drep", size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["drep_detail_breadcrumb"], size="2", weight="medium"),
-        spacing="2",
-        align="center",
-        width="100%",
-        padding_top="15px",
+    return breadcrumb(
+        [("nav_governance", "/governance"), ("gov_subnav_drep", "/governance/drep")],
+        "drep_detail_breadcrumb",
     )
 
 

--- a/cardanoism/pages/governance_matrix.py
+++ b/cardanoism/pages/governance_matrix.py
@@ -45,6 +45,7 @@ from cardanoism.backend.vote_matrix_db import (
     get_dreps_for_matrix,
     get_votes_for_matrix,
 )
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.governance_nav import governance_subnav
 
 logger = logging.getLogger(__name__)
@@ -295,18 +296,7 @@ class VoteMatrixState(rx.State):
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_governance"], href="/governance",
-                size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["gov_subnav_matrix"], size="2", weight="medium"),
-        spacing="2",
-        align="center",
-        width="100%",
-        padding_top="15px",
-    )
+    return breadcrumb([("nav_governance", "/governance")], "gov_subnav_matrix")
 
 
 def _filter_bar() -> rx.Component:

--- a/cardanoism/pages/governance_treasury.py
+++ b/cardanoism/pages/governance_treasury.py
@@ -33,6 +33,7 @@ from cardanoism.backend.price import (
     format_jpy_short,
     format_usd_short,
 )
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.governance_nav import governance_subnav
 from cardanoism.components.login_modal import login_modal
 
@@ -486,17 +487,7 @@ def _fiat_inline(jpy_var, usd_var, color: str = "var(--gray-10)", size: str = "2
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_governance"], href="/governance", size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["gov_subnav_treasury"], size="2", weight="medium"),
-        spacing="2",
-        align="center",
-        width="100%",
-        padding_top="15px",
-    )
+    return breadcrumb([("nav_governance", "/governance")], "gov_subnav_treasury")
 
 
 # ─── トレジャリー残高 折れ線グラフ ─────────────────────────────────────────────

--- a/cardanoism/pages/governance_why.py
+++ b/cardanoism/pages/governance_why.py
@@ -39,6 +39,7 @@ from cardanoism.backend.treasury_db import (
 from cardanoism.backend.drep_db import get_dreps, sum_total_delegation
 from cardanoism.backend.koios import get_current_epoch
 from cardanoism.backend.price import format_ada, format_ada_short_ja, format_ada_short_en
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.governance_nav import governance_subnav
 from cardanoism.components.login_modal import login_modal
 
@@ -269,16 +270,7 @@ def _bold_metric(value: str, unit: str = "", color: str = "var(--amber-11)") -> 
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_governance"], href="/governance",
-                size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["gov_subnav_why"], size="2", weight="medium"),
-        spacing="2", align="center", width="100%",
-        padding_top="15px",
-    )
+    return breadcrumb([("nav_governance", "/governance")], "gov_subnav_why")
 
 
 # ─── S1: ガバナンスとは？ ─────────────────────────────────

--- a/cardanoism/pages/pricing.py
+++ b/cardanoism/pages/pricing.py
@@ -13,6 +13,7 @@ import reflex as rx
 from cardanoism.templates import template
 from cardanoism.backend.auth_state import AuthState
 from cardanoism.backend.plan_config import PLANS, BETA_MODE, COMPARISON_SECTIONS, PlanDetails
+from cardanoism.components.breadcrumb import breadcrumb
 
 logger = logging.getLogger(__name__)
 
@@ -51,12 +52,7 @@ def _shell(*children, **kw) -> rx.Component:
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["pricing_title"], size="2", weight="medium"),
-        spacing="2", align="center", width="100%", padding_top="15px",
-    )
+    return breadcrumb([], "pricing_title")
 
 
 def _hero() -> rx.Component:

--- a/cardanoism/pages/staking.py
+++ b/cardanoism/pages/staking.py
@@ -24,6 +24,7 @@ from cardanoism.backend.recent_blocks_db import get_recent_blocks
 from cardanoism.backend.mempool_db import get_mempool_state
 
 import json as _json
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.staking_nav import staking_subnav
 from cardanoism.components.login_modal import login_modal
 
@@ -421,15 +422,7 @@ class StakingDashboardState(rx.State):
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["nav_staking"], size="2", weight="medium"),
-        spacing="2",
-        align="center",
-        width="100%",
-        padding_top="15px",
-    )
+    return breadcrumb([], "nav_staking")
 
 
 def _stat_card(icon: str, label, value, sub=None, accent: str = "var(--amber-9)") -> rx.Component:

--- a/cardanoism/pages/staking_spo.py
+++ b/cardanoism/pages/staking_spo.py
@@ -20,6 +20,7 @@ from cardanoism.backend.fiat_db import get_fiat_rate
 from cardanoism.backend.koios import get_totals
 from cardanoism.backend.pool_db import get_pools, count_pools
 from cardanoism.backend.price import format_ada, format_ada_short_ja, format_ada_short_en
+from cardanoism.components.breadcrumb import breadcrumb
 from cardanoism.components.staking_nav import staking_subnav
 from cardanoism.components.delegation_dialog import delegation_dialog
 
@@ -287,17 +288,7 @@ class StakingSPOState(rx.State):
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_staking"], href="/staking", size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["staking_subnav_spo"], size="2", weight="medium"),
-        spacing="2",
-        align="center",
-        width="100%",
-        padding_top="15px",
-    )
+    return breadcrumb([("nav_staking", "/staking")], "staking_subnav_spo")
 
 
 def _saturation_bar(p) -> rx.Component:

--- a/cardanoism/pages/staking_why.py
+++ b/cardanoism/pages/staking_why.py
@@ -24,6 +24,7 @@ import reflex as rx
 from cardanoism.templates import template
 from cardanoism.backend.auth_state import AuthState
 from cardanoism.components.staking_nav import staking_subnav
+from cardanoism.components.breadcrumb import breadcrumb
 
 
 ACCENT       = "#ffcf00"
@@ -77,15 +78,7 @@ def _section_heading(kicker, title, subtitle=None) -> rx.Component:
 
 
 def _breadcrumb() -> rx.Component:
-    return rx.hstack(
-        rx.link(rx.icon("home", size=16), href="/", underline="none", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.link(AuthState.t["nav_staking"], href="/staking",
-                size="2", underline="hover", color_scheme="gray"),
-        rx.icon("chevron-right", size=14, color="gray"),
-        rx.text(AuthState.t["staking_subnav_why"], size="2", weight="medium"),
-        spacing="2", align="center", width="100%", padding_top="15px",
-    )
+    return breadcrumb([("nav_staking", "/staking")], "staking_subnav_why")
 
 
 def _bullet_card(icon: str, color: str, title_key: str, desc_key: str) -> rx.Component:


### PR DESCRIPTION
- components/breadcrumb.py 新設、9 ページの _breadcrumb 同型コピペを集約
- components/subnav_pill.py 新設、governance_nav / staking_nav の _pill 重複を解消
- 全 13 ファイルで -196 / +37 行（実質 ~160 行削減）