### PR TITLE
feat(matrix/spo): 投票理由モーダル + プール検索の bech32 ID 分離

### DIFF
--- a/cardanoism/backend/pool_db.py
+++ b/cardanoism/backend/pool_db.py
@@ -209,9 +209,15 @@ def get_pools(
         # registered と retiring (これから退役) は表示する。retired は除外。
         where.append("(pool_status IS NULL OR pool_status <> 'retired')")
     if search:
-        where.append("(ticker LIKE ? OR pool_name LIKE ? OR pool_id_bech32 LIKE ?)")
-        sv = f"%{search}%"
-        params.extend([sv, sv, sv])
+        # 入力値が pool1 で始まるときだけ pool_id_bech32 を検索対象にする。
+        # それ以外は ticker / pool_name のみ (Pool ID 文字列のノイズマッチを避ける)。
+        if search.lower().startswith("pool1"):
+            where.append("pool_id_bech32 LIKE ?")
+            params.append(f"%{search}%")
+        else:
+            where.append("(ticker LIKE ? OR pool_name LIKE ?)")
+            sv = f"%{search}%"
+            params.extend([sv, sv])
 
     if sort == "random":
         # int キャストで SQL インジェクションを防ぐ（識別子位置のため ? バインドが効かない）
@@ -246,9 +252,14 @@ def count_pools(search: str = "", only_active: bool = True) -> int:
     if only_active:
         where.append("(pool_status IS NULL OR pool_status <> 'retired')")
     if search:
-        where.append("(ticker LIKE ? OR pool_name LIKE ? OR pool_id_bech32 LIKE ?)")
-        sv = f"%{search}%"
-        params.extend([sv, sv, sv])
+        # pools_list と同じ条件分岐 (pool1 始まりのみ pool_id_bech32 を対象に)
+        if search.lower().startswith("pool1"):
+            where.append("pool_id_bech32 LIKE ?")
+            params.append(f"%{search}%")
+        else:
+            where.append("(ticker LIKE ? OR pool_name LIKE ?)")
+            sv = f"%{search}%"
+            params.extend([sv, sv])
     sql = f"SELECT COUNT(*) AS cnt FROM pools WHERE {' AND '.join(where)}"
     with get_db() as (cursor, _):
         cursor.execute(sql, params)

--- a/cardanoism/pages/governance_matrix.py
+++ b/cardanoism/pages/governance_matrix.py
@@ -507,11 +507,13 @@ def _drep_name_cell(row) -> rx.Component:
 
 
 def _vote_cell(c) -> rx.Component:
-    tip = rx.cond(
+    rationale_text = rx.cond(
         AuthState.language == "ja",
         rx.cond(c["rationale_ja"] != "", c["rationale_ja"], c["rationale"]),
         c["rationale"],
     )
+    has_rationale = (c["rationale_ja"] != "") | (c["rationale"] != "")
+
     badge = rx.match(
         c["vote"],
         ("yes",     rx.badge("Yes", color_scheme="green", variant="solid", size="1", radius="small")),
@@ -523,9 +525,70 @@ def _vote_cell(c) -> rx.Component:
             "fontWeight": "600",
         }),
     )
+
+    # 投票理由がある場合のみクリップアイコンを出す。クリックでダイアログを開く。
+    clip = rx.cond(
+        has_rationale,
+        rx.dialog.root(
+            rx.dialog.trigger(
+                rx.el.button(
+                    rx.icon("paperclip", size=12, color="var(--gray-10)"),
+                    rx.text(
+                        AuthState.t["dashboard_vote_rationale"],
+                        size="1",
+                        color="var(--gray-11)",
+                    ),
+                    style={
+                        "display":        "inline-flex",
+                        "alignItems":     "center",
+                        "gap":            "3px",
+                        "padding":        "2px 6px",
+                        "background":     "transparent",
+                        "border":         "1px solid var(--gray-5)",
+                        "borderRadius":   "999px",
+                        "cursor":         "pointer",
+                    },
+                    _hover={
+                        "background": "var(--gray-3)",
+                        "color":      "var(--gray-12)",
+                    },
+                ),
+            ),
+            rx.dialog.content(
+                rx.dialog.title(AuthState.t["dashboard_vote_rationale_title"], size="4"),
+                rx.scroll_area(
+                    rx.text(
+                        rationale_text,
+                        size="2", color="var(--gray-12)",
+                        style={"whiteSpace": "pre-wrap", "lineHeight": "1.6"},
+                    ),
+                    type="auto", scrollbars="vertical",
+                    style={"maxHeight": "60vh"},
+                ),
+                rx.flex(
+                    rx.dialog.close(
+                        rx.button(
+                            AuthState.t["dashboard_vote_rationale_close"],
+                            size="2", variant="soft", color_scheme="gray", cursor="pointer",
+                        ),
+                    ),
+                    justify="end", margin_top="16px",
+                ),
+                max_width="640px",
+            ),
+        ),
+        rx.fragment(),
+    )
+
     return rx.el.td(
-        badge,
-        title=tip,
+        rx.flex(
+            badge,
+            clip,
+            direction="row",
+            align="center",
+            justify="center",
+            gap="4px",
+        ),
         style={
             "padding":       "8px",
             "textAlign":     "center",


### PR DESCRIPTION
- 投票マトリクスのセルに paperclip アイコン付き「理由」ピルを追加し、 クリックで投票理由をモーダル表示。マウスオーバーツールチップは廃止
- プール検索: 入力が pool1 で始まるときだけ pool_id_bech32 を検索対象に。 それ以外は ticker / pool_name のみ。Pool ID 文字列のノイズマッチを回避