### PR TITLE
fix(governance): GA カードはみ出し修正 + NCL バー残額を最前面表示

### DIFF
--- a/cardanoism/components/governance_card.py
+++ b/cardanoism/components/governance_card.py
@@ -1722,6 +1722,12 @@ def ga_list_card(action: Dict[str, Any]) -> rx.Component:
             line_height="1.2",
             color="var(--gray-12)",
             class_name="ga-title proposal-title",
+            # 長文や URL-like 文字列が枠からはみ出ないように
+            style={
+                "wordBreak":    "break-word",
+                "overflowWrap": "anywhere",
+                "width":        "100%",
+            },
         ),
         _withdrawal_inline(action),
         rx.cond(
@@ -1734,6 +1740,11 @@ def ga_list_card(action: Dict[str, Any]) -> rx.Component:
                 class_name="mt-2 line-clamp-3",
                 min_height="3.6em",
                 color="var(--gray-12)",
+                style={
+                    "wordBreak":    "break-word",
+                    "overflowWrap": "anywhere",
+                    "width":        "100%",
+                },
             ),
             rx.fragment(),
         ),
@@ -1746,19 +1757,33 @@ def ga_list_card(action: Dict[str, Any]) -> rx.Component:
         href="/governance/" + action["proposal_id"].to(str),
         underline="none",
         color="inherit",
-        style={"display": "block", "flex": "1", "minWidth": "0"},
+        style={
+            "display":     "block",
+            "width":       "100%",
+            # iOS / Android のタップ時の黄色いハイライトを消す
+            "WebkitTapHighlightColor": "transparent",
+            "outline":     "none",
+        },
     )
     desktop_clickable = rx.vstack(
         *inner_children,
         spacing="3",
-        flex="1",
+        width="100%",
         min_width="0",
         on_click=GovernanceState.open_modal(action),
         cursor="pointer",
     )
+    # mobile_only / tablet_and_desktop の wrapper div に flex を効かせるため、
+    # rx.box で囲んで flex/min-width を持たせる。
     content = rx.hstack(
-        rx.mobile_only(mobile_clickable),
-        rx.tablet_and_desktop(desktop_clickable),
+        rx.box(
+            rx.mobile_only(mobile_clickable),
+            rx.tablet_and_desktop(desktop_clickable),
+            flex="1",
+            min_width="0",
+            width="100%",
+            style={"overflow": "hidden"},
+        ),
         rx.box(
             _ga_fav_btn_list(action),
             flex_shrink="0",
@@ -1767,6 +1792,7 @@ def ga_list_card(action: Dict[str, Any]) -> rx.Component:
         align="start",
         spacing="2",
         width="100%",
+        style={"minWidth": "0"},
     )
 
     return rx.card(
@@ -1837,7 +1863,14 @@ def ga_grid_card(action: Dict[str, Any]) -> rx.Component:
         href="/governance/" + action["proposal_id"].to(str),
         underline="none",
         color="inherit",
-        style={"display": "block", "width": "100%", "height": "100%"},
+        style={
+            "display": "block",
+            "width":   "100%",
+            "height":  "100%",
+            # iOS / Android のタップ時の黄色いハイライトを消す
+            "WebkitTapHighlightColor": "transparent",
+            "outline": "none",
+        },
     )
     desktop_clickable = rx.vstack(
         *grid_inner,

--- a/cardanoism/pages/governance_treasury.py
+++ b/cardanoism/pages/governance_treasury.py
@@ -661,6 +661,7 @@ def _ncl_card() -> rx.Component:
     )
 
     progress_bar = rx.box(
+        # ── 色塗りセグメント ──
         rx.hstack(
             # 引き出し確定
             rx.box(
@@ -678,30 +679,12 @@ def _ncl_card() -> rx.Component:
                 transition="width 0.5s ease",
                 flex_shrink="0",
             ),
-            # 残り（テキスト入りセグメント）
-            rx.center(
-                rx.hstack(
-                    rx.text(
-                        AuthState.t["ncl_remaining_label"],
-                        size="1", color="var(--gray-11)", weight="medium",
-                    ),
-                    rx.text(
-                        TreasuryState.ncl_remaining_ada_display,
-                        size="2", weight="bold", color="var(--gray-12)",
-                    ),
-                    rx.text("ADA", size="1", color="var(--gray-11)"),
-                    rx.text(
-                        "(" + TreasuryState.ncl_remaining_pct_display + "%)",
-                        size="1", color="var(--gray-10)",
-                    ),
-                    spacing="1", align="baseline",
-                    white_space="nowrap",
-                ),
+            # 残り (背景のみ)
+            rx.box(
                 width=TreasuryState.ncl_remaining_pct.to_string() + "%",
                 height="100%",
-                background="var(--gray-3)",
+                background="var(--gray-4)",
                 transition="width 0.5s ease",
-                overflow="hidden",
                 flex_shrink="0",
             ),
             spacing="0",
@@ -709,6 +692,41 @@ def _ncl_card() -> rx.Component:
             height="100%",
             align="stretch",
         ),
+        # ── 残額ラベルを絶対配置でバーの最前面に重ねる ──
+        # バーの右端から内側に寄せて表示。常に同じ位置に出るので、
+        # シミュレーション増減で残り領域が細くなっても隠れない。
+        rx.box(
+            rx.hstack(
+                rx.text(
+                    AuthState.t["ncl_remaining_label"],
+                    size="1", weight="medium",
+                    color="var(--gray-12)",
+                ),
+                rx.text(
+                    TreasuryState.ncl_remaining_ada_display,
+                    size="2", weight="bold", color="var(--gray-12)",
+                ),
+                rx.text("ADA", size="1", color="var(--gray-11)"),
+                rx.text(
+                    "(" + TreasuryState.ncl_remaining_pct_display + "%)",
+                    size="1", color="var(--gray-11)",
+                ),
+                spacing="1", align="baseline", white_space="nowrap",
+            ),
+            style={
+                "position":    "absolute",
+                "top":         "50%",
+                "right":       "12px",
+                "transform":   "translateY(-50%)",
+                "zIndex":      2,
+                # 読みやすさのために半透明背景を敷く (どのセグメントの上に乗っても可視性を確保)
+                "padding":     "0 8px",
+                "background":  "rgba(255,255,255,0.85)",
+                "borderRadius": "9999px",
+                "pointerEvents": "none",
+            },
+        ),
+        position="relative",  # 上記 absolute の基準
         width="100%",
         height="30px",
         background="var(--gray-3)",


### PR DESCRIPTION
- スマホ GA 一覧カードのタイトル / 概要がカード外にはみ出る問題を修正:
  - word-break:break-word + overflow-wrap:anywhere をテキストに付与
  - mobile_only / tablet_and_desktop の wrapper を rx.box で囲み、 flex:1 / min-width:0 を実体側に持たせて圧縮挙動を正常化
- スマホ GA カードタップ時の黄色ハイライトを抑止 (WebkitTapHighlightColor: transparent + outline: none)
- NCL 消化バー: 残額ラベルをバー内 position:absolute で最前面に固定。 シミュレーション増加で残り領域が狭くなっても切れずに常に右端表示。 半透明ピル背景でどのセグメント色の上でも可読性を確保