### PR TITLE
fix(navbar/governance): ロゴ伸縮 + ナビ折返し抑止 + 言語切替をフッターへ + GA 並び順

### DIFF
--- a/cardanoism/backend/db_connect.py
+++ b/cardanoism/backend/db_connect.py
@@ -1554,7 +1554,9 @@ class GovernanceState(rx.State):
             " FROM governance_actions ga"
             " LEFT JOIN proposal_voting_summary vs ON ga.proposal_id = vs.proposal_id"
             f" WHERE {where_sql}"
-            " ORDER BY ga.proposed_epoch DESC, ga.id DESC"
+            # 提出順 (新しい順)。同一 Tx 内 (= 同じ proposal_tx_hash) は
+            # proposal_index ASC で並べる (1 Tx に複数 GA が含まれるケース対応)。
+            " ORDER BY ga.block_time DESC, ga.proposed_epoch DESC, ga.proposal_index ASC"
             f" LIMIT {self.items_per_page} OFFSET {offset}"
         )
         count_sql = f"SELECT COUNT(*) AS cnt FROM governance_actions ga WHERE {where_sql}"

--- a/cardanoism/backend/vote_matrix_db.py
+++ b/cardanoism/backend/vote_matrix_db.py
@@ -67,7 +67,7 @@ def get_gas_for_matrix(
                proposed_epoch
           FROM governance_actions
           {where}
-         ORDER BY block_time DESC, proposed_epoch DESC, proposal_id
+         ORDER BY block_time DESC, proposed_epoch DESC, proposal_index ASC
          LIMIT ? OFFSET ?
     """
     with get_db() as (cursor, _):

--- a/cardanoism/components/footer.py
+++ b/cardanoism/components/footer.py
@@ -3,6 +3,7 @@ from reflex.style import set_color_mode, color_mode
 
 from cardanoism.backend.auth_state import AuthState
 from cardanoism.components.cookie_banner import cookie_settings_link
+from cardanoism.components.navbar import lang_toggle
 
 
 
@@ -84,7 +85,9 @@ def dark_mode_toggle() -> rx.Component:
 def socials() -> rx.Component:
     return rx.flex(
         dark_mode_toggle(),
+        lang_toggle(),
         spacing="3",
+        align="center",
         justify_content=["center", "center", "end"],
         width="100%",
     )

--- a/cardanoism/components/navbar.py
+++ b/cardanoism/components/navbar.py
@@ -21,6 +21,9 @@ _PILL = {
     "color": "var(--gray-11)",
     "transition": "background 0.15s, color 0.15s",
     "cursor": "pointer",
+    # JA モードで「ステーキング」「ガバナンス」等が縦に折り返さないように
+    "whiteSpace": "nowrap",
+    "flexShrink": 0,
 }
 _PILL_HOVER = {
     "backgroundColor": "var(--gray-a3)",
@@ -78,6 +81,7 @@ def lang_toggle() -> rx.Component:
             size="2",
             weight="medium",
             color="var(--gray-11)",
+            style={"whiteSpace": "nowrap"},
         ),
         on_click=AuthState.set_language(next_lang),
         style={
@@ -90,6 +94,8 @@ def lang_toggle() -> rx.Component:
             "borderRadius": "9999px",
             "cursor":       "pointer",
             "transition":   "background 0.15s, color 0.15s, border-color 0.15s",
+            "whiteSpace":   "nowrap",
+            "flexShrink":   0,
         },
         _hover={
             "background":   rx.color("gray", 3),
@@ -255,8 +261,8 @@ def auth_section() -> rx.Component:
                     cursor="pointer",
                     padding="0",
                     border_radius="full",
-                    style={"outline": "2px solid transparent", "transition": "outline-color 0.15s"},
-                    _hover={"outline": f"2px solid {ACCENT}"},
+                    style={"outline": "none", "background": "transparent"},
+                    _hover={"background": "transparent", "outline": "none"},
                 ),
             ),
             rx.menu.content(
@@ -299,17 +305,27 @@ def auth_section() -> rx.Component:
 
 
 def navbar_icons() -> rx.Component:
+    # ロゴ: 画像要素の min-width が intrinsic サイズに固定されると、JA モードで
+    # ナビ項目が長いときに縮められず横にあふれる。max-width + 100% で柔軟に
+    # 縮むようにし、ナビ項目側にも flex-shrink を許容する。
     logo = rx.link(
         rx.image(
             src=rx.color_mode_cond(
                 light="/cardanoism-new-logo-light.png",
                 dark="/cardanoism-new-logo-dark.png",
             ),
-            width="13em",
+            width="100%",
+            max_width="13em",
             height="auto",
             alt="カルダノイズム",
+            style={"minWidth": "0"},
         ),
         href="/",
+        style={
+            "flex":     "0 1 13em",  # 基本 13em、足りなければ縮む
+            "minWidth": "0",
+            "display":  "block",
+        },
     )
 
     divider = rx.box(
@@ -364,8 +380,6 @@ def navbar_icons() -> rx.Component:
             rx.box(flex="1"),
             rx.hstack(
                 fiat_rates_pill(),
-                divider,
-                lang_toggle(),
                 divider,
                 rx.cond(
                     WalletState.connected,
@@ -468,7 +482,6 @@ def navbar_icons() -> rx.Component:
     )
 
     drawer_footer = rx.vstack(
-        lang_toggle(),
         rx.cond(
             AuthState.is_logged_in,
             rx.drawer.close(


### PR DESCRIPTION
- グローバルメニュー:
  - JA モードでナビ pill 内テキストが縦に折返す問題を解消 (_PILL に white-space: nowrap + flex-shrink: 0、lang_toggle 同様)
  - ロゴを responsive にして横幅不足時に縮むように (width: 100%, max-width: 13em, min-width: 0, flex: 0 1 13em)
  - 言語切替ボタンをヘッダーから削除し、フッターの明暗モードトグル右隣に移動
  - ログイン中ユーザーのアバターホバー時の黄色アウトラインを削除
- ガバナンス提案一覧 / 投票マトリクスの並び順を統一: ORDER BY block_time DESC, proposed_epoch DESC, proposal_index ASC (1 Tx に複数 GA が含まれるケースで proposal_index 順に整列)