### PR TITLE
fix(matrix): proposal_index を時間方向と逆向きに並べる

### DIFF
--- a/cardanoism/backend/vote_matrix_db.py
+++ b/cardanoism/backend/vote_matrix_db.py
@@ -55,14 +55,17 @@ def get_gas_for_matrix(
 
     order:
       - "asc"  (デフォルト): 左 → 右 = 古い → 新しい (時系列順)。
-                            同一 Tx 内は proposal_index ASC (小 → 大)
+                            同一 Tx 内は proposal_index DESC (大 → 小、後に処理された
+                            提案ほど「新しい」扱い → 右側に配置)
       - "desc":              左 → 右 = 新しい → 古い (新着順)。
-                            同一 Tx 内は proposal_index DESC (大 → 小)
+                            同一 Tx 内は proposal_index ASC (小 → 大)
 
     戻り値要素: {proposal_id, title, title_ja, proposal_type, expiration, proposed_epoch}
     """
     where = _ga_status_where(status)
     direction = "DESC" if (order or "").lower() == "desc" else "ASC"
+    # proposal_index は時間方向と反対 (asc 時に大 → 小、desc 時に小 → 大)
+    index_direction = "ASC" if direction == "DESC" else "DESC"
     sql = f"""
         SELECT proposal_id,
                title,
@@ -72,7 +75,7 @@ def get_gas_for_matrix(
                proposed_epoch
           FROM governance_actions
           {where}
-         ORDER BY block_time {direction}, proposed_epoch {direction}, proposal_index {direction}
+         ORDER BY block_time {direction}, proposed_epoch {direction}, proposal_index {index_direction}
          LIMIT ? OFFSET ?
     """
     with get_db() as (cursor, _):


### PR DESCRIPTION
投票マトリクスの GA 並び順で、order=asc (左=古→右=新) のとき
proposal_index は DESC (大→小)、order=desc のとき ASC (小→大) に する。同一 Tx 内で後に処理された proposal_index が「新しい」扱い
になるため、時間軸と方向を逆にする必要があった。

ORDER BY block_time {dir}, proposed_epoch {dir}, proposal_index {!dir}