### PR TITLE
fix(treasury): NCL 期間内 GA 一覧の並び順を統一

### DIFF
--- a/cardanoism/backend/treasury_db.py
+++ b/cardanoism/backend/treasury_db.py
@@ -417,7 +417,11 @@ def get_treasury_proposals_in_epoch_range(start_epoch: int, end_epoch: int) -> l
     - proposed_epoch が期間内、または
     - enacted_epoch が期間内
     のいずれかを含む（＝ステータスを問わず期間内に登場した提案）。
-    最新順。
+
+    並び順は新着順 (block_time DESC)。同一 Tx 内 (= 同 block_time) は
+    proposal_index ASC で並べる (時間 DESC とは反対方向: 後で処理された
+    proposal_index ほど「新しい」扱いになるが、リストでは新着順なので
+    Tx 内では最初の proposal を上に出す)。
     """
     from cardanoism.backend.db_connect import _GA_STATUS_SQL  # 循環 import 回避のため関数内
     with get_db() as (cursor, _):
@@ -434,7 +438,7 @@ def get_treasury_proposals_in_epoch_range(start_epoch: int, end_epoch: int) -> l
                     (proposed_epoch BETWEEN ? AND ?)
                  OR (enacted_epoch  BETWEEN ? AND ?)
               )
-            ORDER BY proposed_epoch DESC, id DESC
+            ORDER BY block_time DESC, proposed_epoch DESC, proposal_index ASC
             """,
             (int(start_epoch), int(end_epoch), int(start_epoch), int(end_epoch)),
         )


### PR DESCRIPTION
get_treasury_proposals_in_epoch_range の ORDER BY を proposed_epoch DESC, id DESC から
block_time DESC, proposed_epoch DESC, proposal_index ASC に変更。 新着順 (block_time DESC) では同一 Tx 内で proposal_index ASC とする ルールに合わせる (投票マトリクス desc 方向と同じ)。