### PR TITLE
fix(governance/treasury): proposal_index の並び順を時間方向と同じに統一

### DIFF
--- a/cardanoism/backend/db_connect.py
+++ b/cardanoism/backend/db_connect.py
@@ -1555,8 +1555,8 @@ class GovernanceState(rx.State):
             " LEFT JOIN proposal_voting_summary vs ON ga.proposal_id = vs.proposal_id"
             f" WHERE {where_sql}"
             # 提出順 (新しい順)。同一 Tx 内 (= 同じ proposal_tx_hash) は
-            # proposal_index ASC で並べる (1 Tx に複数 GA が含まれるケース対応)。
-            " ORDER BY ga.block_time DESC, ga.proposed_epoch DESC, ga.proposal_index ASC"
+            # proposal_index DESC (時間方向と同じ) で並べる。
+            " ORDER BY ga.block_time DESC, ga.proposed_epoch DESC, ga.proposal_index DESC"
             f" LIMIT {self.items_per_page} OFFSET {offset}"
         )
         count_sql = f"SELECT COUNT(*) AS cnt FROM governance_actions ga WHERE {where_sql}"

--- a/cardanoism/backend/treasury_db.py
+++ b/cardanoism/backend/treasury_db.py
@@ -419,9 +419,7 @@ def get_treasury_proposals_in_epoch_range(start_epoch: int, end_epoch: int) -> l
     のいずれかを含む（＝ステータスを問わず期間内に登場した提案）。
 
     並び順は新着順 (block_time DESC)。同一 Tx 内 (= 同 block_time) は
-    proposal_index ASC で並べる (時間 DESC とは反対方向: 後で処理された
-    proposal_index ほど「新しい」扱いになるが、リストでは新着順なので
-    Tx 内では最初の proposal を上に出す)。
+    proposal_index DESC で並べる (時間 DESC と同じ方向)。
     """
     from cardanoism.backend.db_connect import _GA_STATUS_SQL  # 循環 import 回避のため関数内
     with get_db() as (cursor, _):
@@ -438,7 +436,7 @@ def get_treasury_proposals_in_epoch_range(start_epoch: int, end_epoch: int) -> l
                     (proposed_epoch BETWEEN ? AND ?)
                  OR (enacted_epoch  BETWEEN ? AND ?)
               )
-            ORDER BY block_time DESC, proposed_epoch DESC, proposal_index ASC
+            ORDER BY block_time DESC, proposed_epoch DESC, proposal_index DESC
             """,
             (int(start_epoch), int(end_epoch), int(start_epoch), int(end_epoch)),
         )

--- a/cardanoism/backend/vote_matrix_db.py
+++ b/cardanoism/backend/vote_matrix_db.py
@@ -55,17 +55,14 @@ def get_gas_for_matrix(
 
     order:
       - "asc"  (デフォルト): 左 → 右 = 古い → 新しい (時系列順)。
-                            同一 Tx 内は proposal_index DESC (大 → 小、後に処理された
-                            提案ほど「新しい」扱い → 右側に配置)
-      - "desc":              左 → 右 = 新しい → 古い (新着順)。
                             同一 Tx 内は proposal_index ASC (小 → 大)
+      - "desc":              左 → 右 = 新しい → 古い (新着順)。
+                            同一 Tx 内は proposal_index DESC (大 → 小)
 
     戻り値要素: {proposal_id, title, title_ja, proposal_type, expiration, proposed_epoch}
     """
     where = _ga_status_where(status)
     direction = "DESC" if (order or "").lower() == "desc" else "ASC"
-    # proposal_index は時間方向と反対 (asc 時に大 → 小、desc 時に小 → 大)
-    index_direction = "ASC" if direction == "DESC" else "DESC"
     sql = f"""
         SELECT proposal_id,
                title,
@@ -75,7 +72,7 @@ def get_gas_for_matrix(
                proposed_epoch
           FROM governance_actions
           {where}
-         ORDER BY block_time {direction}, proposed_epoch {direction}, proposal_index {index_direction}
+         ORDER BY block_time {direction}, proposed_epoch {direction}, proposal_index {direction}
          LIMIT ? OFFSET ?
     """
     with get_db() as (cursor, _):


### PR DESCRIPTION
3 箇所すべてで proposal_index を時間方向と一致させる:
- 投票マトリクス: ORDER BY block_time {dir}, ..., proposal_index {dir}
- トレジャリー: proposal_index ASC → DESC
- GA 一覧: proposal_index ASC → DESC

これで新着順 (time DESC) のとき proposal_index も DESC、
古い順 (time ASC) のとき proposal_index も ASC となり、
同一 Tx 内で時間方向と一致する。