### PR TITLE
GA の提案ID/authors 対応・検索 UX 改善と Infisical 認証ドキュメント整理

### DIFF
--- a/cardanoism/backend/db_connect.py
+++ b/cardanoism/backend/db_connect.py
@@ -1509,9 +1509,10 @@ class GovernanceState(rx.State):
         if self.inputed_value:
             sv = f"%{self.inputed_value}%"
             conditions.append(
-                "(ga.title LIKE ? OR ga.title_ja LIKE ? OR ga.`abstract` LIKE ? OR ga.abstract_ja LIKE ?)"
+                "(ga.title LIKE ? OR ga.title_ja LIKE ? OR ga.`abstract` LIKE ?"
+                " OR ga.abstract_ja LIKE ? OR ga.proposal_id LIKE ?)"
             )
-            params.extend([sv, sv, sv, sv])
+            params.extend([sv, sv, sv, sv, sv])
         if self.filter_types:
             placeholders = ", ".join(["?"] * len(self.filter_types))
             conditions.append(f"ga.proposal_type IN ({placeholders})")

--- a/cardanoism/backend/governance.py
+++ b/cardanoism/backend/governance.py
@@ -183,6 +183,18 @@ def _extract_fields(item: dict) -> dict:
     body = meta.get("body") or {}
     refs = body.get("references") or []
 
+    # CIP-100/108: authors は meta_json 直下。1 GA に複数いることがあるので name を配列で持つ。
+    authors = meta.get("authors")
+    author_names = None
+    if isinstance(authors, list):
+        names = [
+            str(a.get("name")).strip()
+            for a in authors
+            if isinstance(a, dict) and a.get("name")
+        ]
+        if names:
+            author_names = json.dumps(names, ensure_ascii=False)
+
     deposit = item.get("deposit")
     meta_is_valid = item.get("meta_is_valid")
     action_anchor_url, action_anchor_hash = _extract_action_anchor(item, body)
@@ -229,6 +241,7 @@ def _extract_fields(item: dict) -> dict:
         "motivation":       body.get("motivation") or None,
         "rationale":        body.get("rationale") or None,
         "references_json":  json.dumps(refs, ensure_ascii=False) if refs else None,
+        "authors_json":     author_names,
         "action_anchor_url":  action_anchor_url,
         "action_anchor_hash": action_anchor_hash,
         "spo_target":         spo_target,
@@ -264,6 +277,7 @@ def upsert_proposal(fields: dict) -> bool:
                 dropped_epoch, expired_epoch, expiration,
                 block_time, meta_url, meta_hash, meta_is_valid,
                 title, `abstract`, motivation, rationale, references_json,
+                authors_json,
                 action_anchor_url, action_anchor_hash,
                 last_event_slot,
                 spo_target
@@ -274,18 +288,20 @@ def upsert_proposal(fields: dict) -> bool:
                 ?, ?, ?,
                 ?, ?, ?, ?,
                 ?, ?, ?, ?, ?,
+                ?,
                 ?, ?,
                 ?,
                 ?
             )
             ON DUPLICATE KEY UPDATE
-                -- ステータスエポック + 引き出し情報 + action anchor を更新
+                -- ステータスエポック + 引き出し情報 + authors + action anchor を更新
                 ratified_epoch            = VALUES(ratified_epoch),
                 enacted_epoch             = VALUES(enacted_epoch),
                 dropped_epoch             = VALUES(dropped_epoch),
                 expired_epoch             = VALUES(expired_epoch),
                 withdrawal_total_lovelace = VALUES(withdrawal_total_lovelace),
                 withdrawal_json           = VALUES(withdrawal_json),
+                authors_json              = VALUES(authors_json),
                 action_anchor_url         = VALUES(action_anchor_url),
                 action_anchor_hash        = VALUES(action_anchor_hash),
                 -- last_event_slot は listener が書いた値を保持 (Koios 由来 NULL で上書きしない)
@@ -305,6 +321,7 @@ def upsert_proposal(fields: dict) -> bool:
                 fields["meta_is_valid"],
                 fields["title"],           fields["abstract"],
                 fields["motivation"],      fields["rationale"],        fields["references_json"],
+                fields.get("authors_json"),
                 fields.get("action_anchor_url"), fields.get("action_anchor_hash"),
                 fields.get("last_event_slot"),
                 fields.get("spo_target"),

--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -168,11 +168,11 @@ UI_JA: dict[str, str] = {
     "gov_type_new_committee": "委員会変更",
     "gov_type_new_constitution": "新憲法",
     "gov_type_no_confidence": "不信任",
-    "gov_status_active": "アクティブ",
-    "gov_status_ratified": "批准済み",
-    "gov_status_enacted": "施行済み",
-    "gov_status_dropped": "廃止",
-    "gov_status_expired": "失効",
+    "gov_status_active": "投票中",
+    "gov_status_ratified": "可決",
+    "gov_status_enacted": "施行",
+    "gov_status_dropped": "否決",
+    "gov_status_expired": "期限切れ",
     "gov_title_none": "（タイトルなし）",
     "gov_proposed_epoch_label": "提案: ",
     "gov_expiration_label": "期限: ",
@@ -246,6 +246,7 @@ UI_JA: dict[str, str] = {
     "gov_vote_rationale_close":    "閉じる",
     "gov_modal_load_error": "詳細を読み込めませんでした",
     "gov_url_copied": "GAリンクをコピーしました",
+    "gov_id_copied": "提案 ID をコピーしました",
     "gov_ref_no_label": "（ラベルなし）",
 
     # ガバナンス サブナビゲーション
@@ -1224,6 +1225,7 @@ UI_EN: dict[str, str] = {
     "gov_vote_rationale_close":    "Close",
     "gov_modal_load_error": "Failed to load details",
     "gov_url_copied": "Link copied",
+    "gov_id_copied": "Proposal ID copied",
     "gov_ref_no_label": "(No label)",
 
     # Governance subnav

--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -262,7 +262,7 @@ UI_JA: dict[str, str] = {
     "matrix_search_placeholder": "DRep 名で検索",
     "matrix_status_label":       "ステータス",
     "matrix_gas_per_page":       "GA 最大表示数",
-    "matrix_order_label":        "並び順",
+    "matrix_order_label":        "提案並び替え",
     "matrix_order_asc":          "古い→新しい",
     "matrix_order_desc":         "新しい→古い",
     # 投票ラベル (matrix セル + GA 詳細バッジ共通)
@@ -1240,7 +1240,7 @@ UI_EN: dict[str, str] = {
     "matrix_search_placeholder": "Search DRep name",
     "matrix_status_label":       "Status",
     "matrix_gas_per_page":       "Max GAs shown",
-    "matrix_order_label":        "Order",
+    "matrix_order_label":        "Sort proposals",
     "matrix_order_asc":          "Old → New",
     "matrix_order_desc":         "New → Old",
     # Vote labels (matrix cell + GA detail badges)

--- a/cardanoism/backend/migrations/004_governance.sql
+++ b/cardanoism/backend/migrations/004_governance.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS governance_actions (
     motivation                MEDIUMTEXT    DEFAULT NULL,
     rationale                 MEDIUMTEXT    DEFAULT NULL,
     references_json           LONGTEXT      DEFAULT NULL,
+    authors_json              TEXT          DEFAULT NULL,             -- CIP-100/108 authors の name 配列 (JSON)
     title_ja                  TEXT          DEFAULT NULL,
     abstract_ja               MEDIUMTEXT    DEFAULT NULL,
     motivation_ja             MEDIUMTEXT    DEFAULT NULL,

--- a/cardanoism/components/dashboard.py
+++ b/cardanoism/components/dashboard.py
@@ -328,19 +328,17 @@ def _drep_vote_badge(vote_var: rx.Var) -> rx.Component:
 
 
 def _drep_vote_rationale_dialog(v: rx.Var) -> rx.Component:
-    """投票理由ダイアログ。rationale が空なら trigger 自体表示しない。"""
+    """投票理由ダイアログ。GA 詳細ページの投票理由ダイアログと同じフォーマット
+    (投票結果バッジ + divider + 日本語訳ラベル + 原文ラベル) で表示する。
+    rationale が空なら trigger 自体表示しない。
+    """
     has_rationale = (v["rationale_ja"] != "") | (v["rationale"] != "")
-    rationale_text = rx.cond(
-        AuthState.language == "ja",
-        rx.cond(v["rationale_ja"] != "", v["rationale_ja"], v["rationale"]),
-        v["rationale"],
-    )
     return rx.cond(
         has_rationale,
         rx.dialog.root(
             rx.dialog.trigger(
                 rx.el.button(
-                    rx.icon("message-square", size=11, color="var(--gray-10)"),
+                    rx.icon("paperclip", size=11, color="var(--gray-10)"),
                     rx.text(AuthState.t["dashboard_vote_rationale"], size="1", color="var(--gray-11)"),
                     style={
                         "display": "inline-flex",
@@ -356,26 +354,55 @@ def _drep_vote_rationale_dialog(v: rx.Var) -> rx.Component:
                 ),
             ),
             rx.dialog.content(
-                rx.dialog.title(AuthState.t["dashboard_vote_rationale_title"], size="4"),
-                rx.scroll_area(
-                    rx.text(
-                        rationale_text,
-                        size="2", color="var(--gray-12)",
-                        style={"whiteSpace": "pre-wrap", "lineHeight": "1.6"},
+                rx.dialog.title(AuthState.t["gov_vote_rationale_title"]),
+                rx.vstack(
+                    # 投票結果バッジ (v["vote"] は "yes"/"no"/"abstain")
+                    rx.match(
+                        v["vote"],
+                        ("yes",     rx.badge(AuthState.t["vote_label_yes"],     color_scheme="green", variant="solid", size="2", radius="full")),
+                        ("no",      rx.badge(AuthState.t["vote_label_no"],      color_scheme="red",   variant="solid", size="2", radius="full")),
+                        ("abstain", rx.badge(AuthState.t["vote_label_abstain"], color_scheme="gray",  variant="solid", size="2", radius="full")),
+                        rx.fragment(),
                     ),
-                    type="auto", scrollbars="vertical",
-                    style={"maxHeight": "60vh"},
-                ),
-                rx.flex(
+                    rx.divider(),
+                    # 日本語訳 (あれば)
+                    rx.cond(
+                        v["rationale_ja"] != "",
+                        rx.vstack(
+                            rx.text(AuthState.t["gov_vote_rationale_ja_label"], size="2", weight="bold", color="var(--gray-12)"),
+                            rx.text(
+                                v["rationale_ja"],
+                                size="2", color="var(--gray-12)",
+                                style={"whiteSpace": "pre-wrap", "lineHeight": "1.6"},
+                            ),
+                            spacing="1", align="start", width="100%",
+                        ),
+                        rx.fragment(),
+                    ),
+                    # 原文 (あれば)
+                    rx.cond(
+                        v["rationale"] != "",
+                        rx.vstack(
+                            rx.text(AuthState.t["gov_vote_rationale_en_label"], size="2", weight="bold", color="var(--gray-12)"),
+                            rx.text(
+                                v["rationale"],
+                                size="2", color="var(--gray-11)",
+                                style={"whiteSpace": "pre-wrap", "lineHeight": "1.6"},
+                            ),
+                            spacing="1", align="start", width="100%",
+                        ),
+                        rx.fragment(),
+                    ),
                     rx.dialog.close(
                         rx.button(
-                            AuthState.t["dashboard_vote_rationale_close"],
-                            size="2", variant="soft", color_scheme="gray", cursor="pointer",
+                            AuthState.t["gov_vote_rationale_close"],
+                            variant="soft", size="2", cursor="pointer",
                         ),
                     ),
-                    justify="end", margin_top="16px",
+                    spacing="3", align="start", width="100%",
                 ),
-                max_width="640px",
+                max_width=["calc(100vw - 16px)", "calc(100vw - 16px)", "680px"],
+                style={"boxSizing": "border-box"},
             ),
         ),
         rx.fragment(),

--- a/cardanoism/components/governance_card.py
+++ b/cardanoism/components/governance_card.py
@@ -116,21 +116,49 @@ def _ref_item(ref: Dict[str, Any]) -> rx.Component:
 
 # ─── 詳細コンテンツ（モーダル・個別ページ共通） ──────────────────────────────
 
-_GOVTOOL_BTN_STYLE = {
-    "display": "inline-flex",
-    "align_items": "center",
-    "gap": "4px",
-    "padding": "4px 10px",
-    "border_radius": "6px",
-    "font_size": "13px",
-    "font_weight": "500",
-    "cursor": "pointer",
-    "border": "1px solid var(--gray-5)",
-    "background": "var(--gray-2)",
-    "color": "var(--gray-11)",
-    "text_decoration": "none",
-    "_hover": {"background": "var(--gray-4)"},
-}
+def _gov_id_row(action: Dict[str, Any]) -> rx.Component:
+    """proposal_id (gov_id) の表示 + コピーボタン。カード・モーダル・詳細ページ共通。
+    カードでは親要素に on_click / link があるため、コピー操作が
+    カード遷移・モーダル展開に伝播しないよう stop_propagation + prevent_default を付ける。
+    """
+    proposal_id = action["proposal_id"].to(str)
+    return rx.hstack(
+        rx.text(
+            proposal_id,
+            size="1",
+            color="var(--gray-10)",
+            style={
+                "fontFamily": "var(--code-font-family, ui-monospace, monospace)",
+                "overflow": "hidden",
+                "textOverflow": "ellipsis",
+                "whiteSpace": "nowrap",
+                "maxWidth": "260px",
+            },
+        ),
+        rx.icon(
+            "copy",
+            size=13,
+            color="var(--gray-9)",
+            cursor="pointer",
+            flex_shrink="0",
+            on_click=[
+                rx.set_clipboard(proposal_id).stop_propagation.prevent_default,
+                rx.toast(
+                    AuthState.t["gov_id_copied"],
+                    position="top-center",
+                    style={
+                        "background-color": "var(--indigo-11)",
+                        "color": "white",
+                        "border-radius": "0.5rem",
+                    },
+                ).stop_propagation.prevent_default,
+            ],
+            style={"_hover": {"color": "var(--gray-12)"}},
+        ),
+        spacing="1",
+        align="center",
+        style={"minWidth": "0"},
+    )
 
 
 def governance_detail_header(action: Dict[str, Any], close_btn=None) -> rx.Component:
@@ -257,23 +285,6 @@ def governance_detail_header(action: Dict[str, Any], close_btn=None) -> rx.Compo
         align="center",
     )
 
-    links_row = rx.cond(
-        action["govtool_url"],
-        rx.link(
-            rx.hstack(
-                rx.text("Gov Tool", size="1"),
-                rx.icon("external-link", size=12),
-                spacing="1",
-                align="center",
-            ),
-            href=action["govtool_url"],
-            is_external=True,
-            underline="none",
-            style=_GOVTOOL_BTN_STYLE,
-        ),
-        rx.fragment(),
-    )
-
     title_row = (
         rx.hstack(
             title_block,
@@ -288,16 +299,9 @@ def governance_detail_header(action: Dict[str, Any], close_btn=None) -> rx.Compo
 
     return rx.vstack(
         title_row,
-        rx.hstack(
-            badge_row,
-            links_row,
-            justify="between",
-            align="center",
-            width="100%",
-            wrap="wrap",
-            spacing="2",
-        ),
+        badge_row,
         epoch_row,
+        rx.hstack(_gov_id_row(action), width="100%", wrap="wrap"),
         rx.divider(),
         spacing="3",
         width="100%",
@@ -1731,6 +1735,7 @@ def ga_list_card(action: Dict[str, Any]) -> rx.Component:
                 "width":        "100%",
             },
         ),
+        _gov_id_row(action),
         _withdrawal_inline(action),
         rx.cond(
             _has_any_text("abstract_ja_card", "abstract_card", action),
@@ -1838,6 +1843,7 @@ def ga_grid_card(action: Dict[str, Any]) -> rx.Component:
             color="var(--gray-12)",
             class_name="ga-title proposal-title",
         ),
+        _gov_id_row(action),
         _withdrawal_inline(action),
         rx.cond(
             _has_any_text("abstract_ja_card", "abstract_card", action),

--- a/cardanoism/components/navbar.py
+++ b/cardanoism/components/navbar.py
@@ -325,6 +325,9 @@ def navbar_icons() -> rx.Component:
             "flex":     "0 1 13em",  # 基本 13em、足りなければ縮む
             "minWidth": "0",
             "display":  "block",
+            # スマホでタップ時の黄色いハイライトを抑止
+            "WebkitTapHighlightColor": "transparent",
+            "outline":  "none",
         },
     )
 

--- a/cardanoism/pages/catalyst.py
+++ b/cardanoism/pages/catalyst.py
@@ -142,6 +142,21 @@ def catalyst() -> rx.Component:
         rx.html(FILTER_THEME_CSS),
         rx.box(
             rx.input(
+                rx.cond(
+                    AppState.search_query != "",
+                    rx.input.slot(
+                        rx.icon(
+                            "x",
+                            size=16,
+                            cursor="pointer",
+                            on_click=AppState.set_inputed_value(""),
+                            style={"_hover": {"color": "var(--gray-12)"}},
+                        ),
+                        side="right",
+                        color="var(--gray-9)",
+                    ),
+                    rx.fragment(),
+                ),
                 placeholder=AuthState.t["catalyst_search_placeholder"],
                 size="3",
                 max_length=100,

--- a/cardanoism/pages/fund.py
+++ b/cardanoism/pages/fund.py
@@ -531,6 +531,21 @@ def fund_detail() -> rx.Component:
         rx.flex(
             rx.box(
                 rx.input(
+                    rx.cond(
+                        AppState.search_query != "",
+                        rx.input.slot(
+                            rx.icon(
+                                "x",
+                                size=16,
+                                cursor="pointer",
+                                on_click=AppState.set_inputed_value(""),
+                                style={"_hover": {"color": "var(--gray-12)"}},
+                            ),
+                            side="right",
+                            color="var(--gray-9)",
+                        ),
+                        rx.fragment(),
+                    ),
                     placeholder="キーワードを入力..(タイトル、タグ、提案情報など)",
                     size="3",
                     max_length=100,

--- a/cardanoism/pages/governance.py
+++ b/cardanoism/pages/governance.py
@@ -214,6 +214,21 @@ def gov_filters() -> rx.Component:
         rx.html(FILTER_CSS),
         rx.box(
             rx.input(
+                rx.cond(
+                    GovernanceState.search_query != "",
+                    rx.input.slot(
+                        rx.icon(
+                            "x",
+                            size=16,
+                            cursor="pointer",
+                            on_click=GovernanceState.set_inputed_value(""),
+                            style={"_hover": {"color": "var(--gray-12)"}},
+                        ),
+                        side="right",
+                        color="var(--gray-9)",
+                    ),
+                    rx.fragment(),
+                ),
                 placeholder=AuthState.t["gov_filter_search_placeholder"],
                 size="3",
                 max_length=100,

--- a/cardanoism/pages/governance_drep.py
+++ b/cardanoism/pages/governance_drep.py
@@ -530,6 +530,21 @@ def _drep_card(d) -> rx.Component:
 def _filter_bar() -> rx.Component:
     return rx.hstack(
         rx.input(
+            rx.cond(
+                DrepState.inputed_value != "",
+                rx.input.slot(
+                    rx.icon(
+                        "x",
+                        size=16,
+                        cursor="pointer",
+                        on_click=DrepState.set_input(""),
+                        style={"_hover": {"color": "var(--gray-12)"}},
+                    ),
+                    side="right",
+                    color="var(--gray-9)",
+                ),
+                rx.fragment(),
+            ),
             placeholder=AuthState.t["drep_search_placeholder"],
             size="3",
             max_length=100,

--- a/cardanoism/pages/governance_matrix.py
+++ b/cardanoism/pages/governance_matrix.py
@@ -313,6 +313,21 @@ def _breadcrumb() -> rx.Component:
 def _filter_bar() -> rx.Component:
     return rx.flex(
         rx.input(
+            rx.cond(
+                VoteMatrixState.inputed_value != "",
+                rx.input.slot(
+                    rx.icon(
+                        "x",
+                        size=16,
+                        cursor="pointer",
+                        on_click=VoteMatrixState.set_search(""),
+                        style={"_hover": {"color": "var(--gray-12)"}},
+                    ),
+                    side="right",
+                    color="var(--gray-9)",
+                ),
+                rx.fragment(),
+            ),
             placeholder=AuthState.t["matrix_search_placeholder"],
             value=VoteMatrixState.inputed_value,
             on_change=VoteMatrixState.set_search.debounce(300),

--- a/cardanoism/pages/governance_matrix.py
+++ b/cardanoism/pages/governance_matrix.py
@@ -342,14 +342,6 @@ def _filter_bar() -> rx.Component:
         rx.hstack(
             rx.text(AuthState.t["matrix_order_label"], size="2", color="var(--gray-11)"),
             rx.el.button(
-                rx.icon(
-                    rx.cond(
-                        VoteMatrixState.ga_order == "asc",
-                        "arrow-right",
-                        "arrow-left",
-                    ),
-                    size=14,
-                ),
                 rx.text(
                     rx.cond(
                         VoteMatrixState.ga_order == "asc",
@@ -363,7 +355,6 @@ def _filter_bar() -> rx.Component:
                 style={
                     "display":      "inline-flex",
                     "alignItems":   "center",
-                    "gap":          "6px",
                     "padding":      "5px 12px",
                     "border":       "1px solid var(--gray-6)",
                     "borderRadius": "9999px",

--- a/cardanoism/pages/governance_treasury.py
+++ b/cardanoism/pages/governance_treasury.py
@@ -34,7 +34,9 @@ from cardanoism.backend.price import (
     format_usd_short,
 )
 from cardanoism.components.breadcrumb import breadcrumb
+from cardanoism.components.governance_card import ga_status_badge
 from cardanoism.components.governance_nav import governance_subnav
+from cardanoism.components.proposal_card import STATUS_DOT_STYLE
 from cardanoism.components.login_modal import login_modal
 
 logger = logging.getLogger(__name__)
@@ -362,7 +364,7 @@ class TreasuryState(rx.State):
                         "enacted_epoch_display": str(int(enacted)) if enacted is not None else "",
                         "is_enacted": "1" if enacted is not None else "",
                         "is_active": "1" if status_str == "active" else "",
-                        "status": status_str,
+                        "ga_status": status_str,
                         "amount_lovelace": str(w_lovelace),
                         "amount_ada": format_ada(w_lovelace, integer=True) if w_lovelace else "-",
                         "amount_jpy": jpy_d,
@@ -864,15 +866,6 @@ _STATUS_COLORS = {
 
 def _proposal_row(p) -> rx.Component:
     """1件の TreasuryWithdrawals 提案カード。active 提案にはシミュレーション用チェックボックス付き。"""
-    status_badge = rx.match(
-        p["status"],
-        ("active",   rx.badge(AuthState.t["gov_status_active"],   color_scheme="green",  variant="soft")),
-        ("ratified", rx.badge(AuthState.t["gov_status_ratified"], color_scheme="blue",   variant="soft")),
-        ("enacted",  rx.badge(AuthState.t["gov_status_enacted"],  color_scheme="violet", variant="soft")),
-        ("dropped",  rx.badge(AuthState.t["gov_status_dropped"],  color_scheme="gray",   variant="soft")),
-        ("expired",  rx.badge(AuthState.t["gov_status_expired"],  color_scheme="gray",   variant="soft")),
-        rx.badge(p["status"], variant="soft"),
-    )
     title_display = rx.cond(
         AuthState.language == "en",
         rx.cond(p["title_en"] != "", p["title_en"], p["title_ja"]),
@@ -882,7 +875,7 @@ def _proposal_row(p) -> rx.Component:
     body = rx.link(
         rx.vstack(
             rx.hstack(
-                status_badge,
+                ga_status_badge(p),
                 rx.text(
                     AuthState.t["ncl_proposal_proposed_label"] + " " + p["proposed_epoch_display"],
                     size="1", color="var(--gray-10)",
@@ -1054,6 +1047,7 @@ def governance_treasury_page() -> rx.Component:
     return rx.cond(
         TreasuryState.load,
         rx.box(
+            STATUS_DOT_STYLE,
             login_modal(),
             rx.vstack(
                 _breadcrumb(),

--- a/cardanoism/pages/mypage.py
+++ b/cardanoism/pages/mypage.py
@@ -1763,26 +1763,32 @@ def mypage() -> rx.Component:
                         rx.tabs.trigger(
                             rx.hstack(rx.icon("layout-dashboard", size=14), rx.text(AuthState.t["tab_dashboard"]), spacing="1"),
                             value="dashboard",
+                            cursor="pointer",
                         ),
                         rx.tabs.trigger(
                             rx.hstack(rx.icon("bookmark", size=14), rx.text(AuthState.t["tab_favorites"]), spacing="1"),
                             value="favorites",
+                            cursor="pointer",
                         ),
                         rx.tabs.trigger(
                             rx.hstack(rx.icon("user", size=14), rx.text(AuthState.t["tab_profile"]), spacing="1"),
                             value="profile",
+                            cursor="pointer",
                         ),
                         rx.tabs.trigger(
                             rx.hstack(rx.icon("wallet", size=14), rx.text(AuthState.t["tab_stake"]), spacing="1"),
                             value="stake",
+                            cursor="pointer",
                         ),
                         rx.tabs.trigger(
                             rx.hstack(rx.icon("bell", size=14), rx.text(AuthState.t["tab_notification"]), spacing="1"),
                             value="notification",
+                            cursor="pointer",
                         ),
                         rx.tabs.trigger(
                             rx.hstack(rx.icon("crown", size=14), rx.text(AuthState.t["tab_subscription"]), spacing="1"),
                             value="subscription",
+                            cursor="pointer",
                         ),
                         wrap="wrap",
                     ),

--- a/cardanoism/pages/staking_spo.py
+++ b/cardanoism/pages/staking_spo.py
@@ -775,6 +775,21 @@ def _metric(label, value, unit: str, emphasis: bool = False) -> rx.Component:
 def _filter_bar() -> rx.Component:
     return rx.hstack(
         rx.input(
+            rx.cond(
+                StakingSPOState.inputed_value != "",
+                rx.input.slot(
+                    rx.icon(
+                        "x",
+                        size=16,
+                        cursor="pointer",
+                        on_click=StakingSPOState.set_input(""),
+                        style={"_hover": {"color": "var(--gray-12)"}},
+                    ),
+                    side="right",
+                    color="var(--gray-9)",
+                ),
+                rx.fragment(),
+            ),
             placeholder=AuthState.t["staking_search_placeholder"],
             size="3",
             max_length=100,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -145,7 +145,7 @@
 
     cron だけでは不十分。**Ogmios listener** がリアルタイム通知を、**GA AI worker** が `ga_ai_initial_sync` で enqueue した GA を順次処理する。両方とも systemd で常駐させる。
 
-    `/etc/cardanoism/infisical.token` に Machine Identity Service Token を配置済みである前提（詳細は `docs/realtime-notification-backend.md § 5-2`）。
+    手順 3 の `sudo -u cardanoism infisical login` で `~/.infisical/` に credentials を保存済みである前提（詳細は `docs/realtime-notification-backend.md § 5-2`）。
 
     **Ogmios listener** `/etc/systemd/system/ogmios-listener.service`:
 
@@ -159,7 +159,7 @@
     Type=simple
     User=cardanoism
     WorkingDirectory=/opt/cardanoism
-    ExecStart=/usr/bin/bash -c '/usr/local/bin/infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- /opt/cardanoism/.venv/bin/python ogmios_listener.py'
+    ExecStart=/usr/local/bin/infisical run --env=mainnet -- /opt/cardanoism/.venv/bin/python ogmios_listener.py
     Restart=always
     RestartSec=10
     StandardOutput=journal
@@ -180,7 +180,7 @@
     Type=simple
     User=cardanoism
     WorkingDirectory=/opt/cardanoism
-    ExecStart=/usr/bin/bash -c '/usr/local/bin/infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- /opt/cardanoism/.venv/bin/python ga_ai_worker.py'
+    ExecStart=/usr/local/bin/infisical run --env=mainnet -- /opt/cardanoism/.venv/bin/python ga_ai_worker.py
     Restart=always
     RestartSec=10
     StandardOutput=journal

--- a/docs/ga-ai-analysis-backend.md
+++ b/docs/ga-ai-analysis-backend.md
@@ -111,7 +111,7 @@ After=mysql.service network.target
 Type=simple
 User=cardanoism
 WorkingDirectory=/path/to/cardanoism
-ExecStart=/usr/bin/bash -c '/usr/local/bin/infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- /path/to/cardanoism/.venv/bin/python /path/to/cardanoism/ga_ai_worker.py'
+ExecStart=/usr/local/bin/infisical run --env=mainnet -- /path/to/cardanoism/.venv/bin/python /path/to/cardanoism/ga_ai_worker.py
 Restart=always
 RestartSec=10
 

--- a/docs/initial-setup.md
+++ b/docs/initial-setup.md
@@ -70,14 +70,16 @@ sudo apt install -y infisical
 infisical --version
 ```
 
-### 3-2. Service Token (非対話認証)
+### 3-2. 認証 (対話 login)
 
-VPS では Machine Identity から発行した Service Token をファイル経由で読み込む。詳細手順は `docs/realtime-notification-backend.md` § 5-2。
+VPS の実行ユーザーで一度だけ対話 login する。credentials は `~/.infisical/` に保存され、以降の `infisical run` で自動参照される。
 
 ```bash
-sudo install -m 0600 /dev/stdin /etc/cardanoism/infisical.token <<< "<TOKEN>"
-sudo chown <user>:<user> /etc/cardanoism/infisical.token
+sudo -u <user> infisical login
+# ブラウザ or デバイス認証フローを完了
 ```
+
+> credentials が期限切れになった場合は同じコマンドで再認証する。
 
 ### 3-3. environment スコープ
 
@@ -90,7 +92,7 @@ sudo chown <user>:<user> /etc/cardanoism/infisical.token
 注入確認:
 
 ```bash
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+infisical run --env=mainnet -- \
   bash -c 'echo "DB=$DB_HOST/$DB_NAME, KOIOS=$KOIOS_NETWORK"'
 ```
 
@@ -103,7 +105,7 @@ infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- 
 `cardanoism/backend/migrations/` 配下の SQL を番号順に流す。すべて `CREATE TABLE IF NOT EXISTS` で冪等。
 
 ```bash
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- bash -c '
+infisical run --env=mainnet -- bash -c '
 for f in cardanoism/backend/migrations/*.sql; do
   echo "--- applying $f"
   mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" < "$f"
@@ -120,7 +122,7 @@ done
 順序が重要。GA 本体が無いと AI 分析の enqueue 対象が無く、NCL 計算も `protocol_params` が前提。
 
 ```bash
-INF="infisical run --env=mainnet --token=$(cat /etc/cardanoism/infisical.token) --"
+INF="infisical run --env=mainnet --"
 PY="/opt/cardanoism/.venv/bin/python"
 
 # (1) GA 本体を governance_actions に取り込む (新規ぶんは AI 分析キューへ自動 enqueue)
@@ -188,7 +190,7 @@ cardano-node + Ogmios が `syncProgress: 100.00` まで同期完了してから�
 
 ```bash
 # 初回 (フォアグラウンドで動作確認)
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+infisical run --env=mainnet -- \
   /opt/cardanoism/.venv/bin/python ogmios_listener.py --from-tip
 ```
 
@@ -206,7 +208,7 @@ journalctl -u ogmios-listener -f
 
 ```bash
 # 初回 (フォアグラウンドで動作確認)
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+infisical run --env=mainnet -- \
   /opt/cardanoism/.venv/bin/python ga_ai_worker.py
 ```
 
@@ -223,7 +225,7 @@ journalctl -u ga-ai-worker -f
 開発モード:
 
 ```bash
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- reflex run
+infisical run --env=mainnet -- reflex run
 ```
 
 本番は `reflex export` + nginx + プロセスマネージャ (例: pm2 / systemd) で `.web/_static` を配信。詳細は Reflex 公式参照。

--- a/docs/realtime-notification-backend.md
+++ b/docs/realtime-notification-backend.md
@@ -212,27 +212,28 @@ python3 -m venv .venv
 | `TELEGRAM_BOT_TOKEN` | ⚠️ | Telegram 通知を使う場合 |
 | `KOIOS_API_KEY` | 任意 | Koios の認証キー（DRep 投票時のタイトル補完・プール実績取得に使用） |
 
-VPS 側で Infisical CLI をインストールし、Machine Identity (Service Token) を発行して非対話認証する:
+VPS 側で Infisical CLI をインストールし、実行ユーザーで対話 login して認証する:
 
 ```bash
 # CLI インストール
 curl -1sLf https://artifacts-cli.infisical.com/setup.deb.sh | sudo -E bash
 sudo apt install -y infisical
 
-# Service Token を保存 (Infisical Web UI → Project → Access Control → Machine Identities で発行)
-sudo install -m 0600 /dev/stdin /etc/cardanoism/infisical.token <<< "<TOKEN>"
-sudo chown cardanoism:cardanoism /etc/cardanoism/infisical.token
+# 実行ユーザーで一度だけ対話 login (credentials は ~/.infisical/ に保存される)
+sudo -u cardanoism infisical login
 ```
+
+> credentials が期限切れになった場合は同じコマンドで再認証する。
 
 ### 5-3. 起動方法
 
 ```bash
 cd /opt/cardanoism
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+infisical run --env=mainnet -- \
     .venv/bin/python ogmios_listener.py
 
 # 初回起動時のみ tip から再開
-infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- \
+infisical run --env=mainnet -- \
     .venv/bin/python ogmios_listener.py --from-tip
 ```
 
@@ -252,8 +253,8 @@ Requires=ogmios.service
 Type=simple
 User=cardanoism
 WorkingDirectory=/opt/cardanoism
-# Infisical Service Token をファイル経由で読み込む (Token 自体は環境変数として漏らさない)
-ExecStart=/usr/bin/bash -c '/usr/local/bin/infisical run --env=mainnet --token="$(cat /etc/cardanoism/infisical.token)" -- /opt/cardanoism/.venv/bin/python ogmios_listener.py'
+# 実行ユーザー (cardanoism) の ~/.infisical/ にある対話 login の credentials を使う
+ExecStart=/usr/local/bin/infisical run --env=mainnet -- /opt/cardanoism/.venv/bin/python ogmios_listener.py
 Restart=always
 RestartSec=10
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- GA カード/モーダル/詳細に提案 ID（gov_id）を表示＋コピーボタン設置、ステータス日本語ラベル変更（投票中/可決/施行/否決/期限切れ）、Gov Tool リンク削除
- GA メタデータの authors（CIP-100/108）を取り込み `governance_actions.authors_json` に保存
- 全ページの検索ボックスに値クリア用の x ボタンを追加、ガバナンス検索の対象に proposal_id を追加
- トレジャリーページの提案ステータスバッジを GA カード共通の `ga_status_badge` に統一
- Infisical 認証を対話 login 方式に統一（deploy/docs）
- 細かな UX 調整（1c6015c）

## DB マイグレーション
本番/テストネット DB に以下の ALTER が必要:
\`\`\`sql
ALTER TABLE governance_actions ADD COLUMN authors_json TEXT DEFAULT NULL AFTER references_json;
\`\`\`