### PR TITLE
cron 環境更新 + requirements/systemd の整備

### DIFF
--- a/deploy/cron.d-cardanoism-notify
+++ b/deploy/cron.d-cardanoism-notify
@@ -24,52 +24,52 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV=mainnet
 
 # Cardanoism リポジトリのチェックアウト先
-WORKDIR=/home/bttokeo/cardanoism_stg
+WORKDIR=/home/btism/cardanoism_tmp
 
 # venv の Python フルパス
-PY=/home/bttokeo/.pyenv/shims/python
+PY=/home/btism/.pyenv/shims/python
 # =============================================================
 
-LOG=/var/log/cardanoism
+LOG=/home/btism/cardanoism_log
 
 # ── 通知 (常時) ───────────────────────────────────────────
 # プール系 (saturation / pledge / reward) — エポック計算値なので cron 必須
-*/10 * * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event pool      >> $LOG/notify-pool.log 2>&1
+*/10 * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event pool      >> $LOG/notify-pool.log 2>&1
 
 # DRep 系 (status_change + drep_unvoted_ga) — drep_unvoted_ga は DB only なので高頻度可能
-*/5  * * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event drep      >> $LOG/notify-drep.log 2>&1
+*/5  * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event drep      >> $LOG/notify-drep.log 2>&1
 
 # 委任リマインダー + stake_addresses 委任先のリフレッシュ
-*/15 * * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event reminder  >> $LOG/notify-reminder.log 2>&1
+*/15 * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event reminder  >> $LOG/notify-reminder.log 2>&1
 
 # トレジャリー引き出し提案の enacted 検知 (listener も拾うが安全網)
-*/15 * * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event treasury  >> $LOG/notify-treasury.log 2>&1
+*/15 * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event treasury  >> $LOG/notify-treasury.log 2>&1
 
 # Active GA の投票集計を最新化 (pre_ratify トリガーの前提)
-*/15 * * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event summary_sync >> $LOG/notify-summary_sync.log 2>&1
+*/15 * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event summary_sync >> $LOG/notify-summary_sync.log 2>&1
 
 # ── オフチェーン同期 (常時) ──────────────────────────────
 # 法定通貨レート (CoinGecko)
-*/5  * * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event fiat_sync           >> $LOG/notify-fiat_sync.log 2>&1
+*/5  * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event fiat_sync           >> $LOG/notify-fiat_sync.log 2>&1
 
 # プールリレー TCP 疎通確認
-0    */6 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event relay_check        >> $LOG/notify-relay_check.log 2>&1
+0    */6 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event relay_check        >> $LOG/notify-relay_check.log 2>&1
 
 # 投票理由の翻訳 (OpenAI、コスト抑制のため低頻度)
-0    */4 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event vote_rationale_sync >> $LOG/notify-vote_rationale_sync.log 2>&1
+0    */4 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event vote_rationale_sync >> $LOG/notify-vote_rationale_sync.log 2>&1
 
 # カタリスト提案フェッチ (Catalyst Explorer API、1 日 1 回 / fund 12-15)
-0    2 * * *  bttokeo cd $WORKDIR && for FUND in 12 13 14 15; do infisical run --env=$ENV -- $PY cardanoism/backend/proposals_update_new.py --fund $FUND; done >> $LOG/catalyst-proposals.log 2>&1
+0    2 * * *  btism cd $WORKDIR && for FUND in 12 13 14 15; do infisical run --env=$ENV -- $PY cardanoism/backend/proposals_update_new.py --fund $FUND; done >> $LOG/catalyst-proposals.log 2>&1
 
 # ── フォールバック (listener 停止対策、24 時間に 1 回深夜) ─────
 # 通常は Ogmios listener が epoch_start を検知してこれらを発火するが、
 # listener が落ちている間でもデータが完全停止しないよう 1 日 1 回バックアップ実行。
 # (summary_sync は常時 15min 実行済みなので fallback には含めない)
-0    3 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY cardanoism/backend/governance.py --no-translate >> $LOG/notify-governance.log 2>&1
-30   3 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event params_sync             >> $LOG/notify-params_sync.log 2>&1
-0    4 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event treasury_sync           >> $LOG/notify-treasury_sync.log 2>&1
-30   4 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event drep_sync               >> $LOG/notify-drep_sync.log 2>&1
-0    5 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event pool_sync               >> $LOG/notify-pool_sync.log 2>&1
-30   5 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event pool_block_history_sync >> $LOG/notify-pool_block_history_sync.log 2>&1
-0    6 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event vote_sync               >> $LOG/notify-vote_sync.log 2>&1
-0    7 * * *  bttokeo cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event constitution_sync       >> $LOG/notify-constitution_sync.log 2>&1
+0    3 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY cardanoism/backend/governance.py --no-translate >> $LOG/notify-governance.log 2>&1
+30   3 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event params_sync             >> $LOG/notify-params_sync.log 2>&1
+0    4 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event treasury_sync           >> $LOG/notify-treasury_sync.log 2>&1
+30   4 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event drep_sync               >> $LOG/notify-drep_sync.log 2>&1
+0    5 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event pool_sync               >> $LOG/notify-pool_sync.log 2>&1
+30   5 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event pool_block_history_sync >> $LOG/notify-pool_block_history_sync.log 2>&1
+0    6 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event vote_sync               >> $LOG/notify-vote_sync.log 2>&1
+0    7 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event constitution_sync       >> $LOG/notify-constitution_sync.log 2>&1

--- a/docs/ga-ai-analysis-backend.md
+++ b/docs/ga-ai-analysis-backend.md
@@ -105,15 +105,19 @@ python ga_ai_worker.py --poll-interval 20 --concurrency 3
 ```ini
 [Unit]
 Description=Cardanoism GA AI Worker
-After=mysql.service network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
-User=cardanoism
-WorkingDirectory=/path/to/cardanoism
-ExecStart=/usr/local/bin/infisical run --env=mainnet -- /path/to/cardanoism/.venv/bin/python /path/to/cardanoism/ga_ai_worker.py
+User=btism
+WorkingDirectory=/home/btism/cardanoism_tmp
+# 実行ユーザー (cardanoism) の ~/.infisical/ にある対話 login の credentials を使う
+ExecStart=/usr/bin/infisical run --env=mainnet -- /home/btism/cardanoism_tmp/.venv/bin/python ga_ai_worker.py
 Restart=always
 RestartSec=10
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/realtime-notification-backend.md
+++ b/docs/realtime-notification-backend.md
@@ -186,9 +186,9 @@ curl http://127.0.0.1:1337/health | jq .
 ### 5-1. リポジトリ配置
 
 ```bash
-sudo mkdir -p /opt/cardanoism
-sudo chown cardanoism:cardanoism /opt/cardanoism
-cd /opt/cardanoism
+sudo mkdir -p /home/btism/cardanoism_tmp
+sudo chown cardanoism:cardanoism /home/btism/cardanoism_tmp
+cd /home/btism/cardanoism_tmp
 git clone <REPO_URL> .
 python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
@@ -228,7 +228,7 @@ sudo -u cardanoism infisical login
 ### 5-3. 起動方法
 
 ```bash
-cd /opt/cardanoism
+cd /home/btism/cardanoism_tmp
 infisical run --env=mainnet -- \
     .venv/bin/python ogmios_listener.py
 
@@ -246,15 +246,15 @@ infisical run --env=mainnet -- \
 ```ini
 [Unit]
 Description=Cardanoism Ogmios Chain Listener
-After=network.target ogmios.service
-Requires=ogmios.service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 User=cardanoism
-WorkingDirectory=/opt/cardanoism
+WorkingDirectory=/home/btism/cardanoism_tmp
 # 実行ユーザー (cardanoism) の ~/.infisical/ にある対話 login の credentials を使う
-ExecStart=/usr/local/bin/infisical run --env=mainnet -- /opt/cardanoism/.venv/bin/python ogmios_listener.py
+ExecStart=/usr/bin/infisical run --env=mainnet -- /home/btism/cardanoism_tmp/.venv/bin/python ogmios_listener.py　
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -263,6 +263,13 @@ StandardError=journal
 [Install]
 WantedBy=multi-user.target
 ```
+
+> **Ogmios が同一ホストにある場合** は `[Unit]` に `After=network-online.target ogmios.service` /
+> `Requires=ogmios.service` を加えると起動順を保証できる。**Ogmios を別サーバで動かす構成**
+> (`OGMIOS_URL` がリモートを指す) では `ogmios.service` がこのホストに存在しないため、
+> これらを書くと `Unit ogmios.service not found` で起動失敗する。上記例はリモート Ogmios
+> 構成向け。`ogmios_listener.py` は WebSocket 接続失敗時に自動再接続するため、起動順を
+> systemd で縛る必要はない。
 
 > preview テストネット用の listener を別途立てるときは `--env=preview` に変更し、別 unit (`ogmios-listener-preview.service`) として登録する。
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,11 @@ utxorpc
 bech32
 websockets>=12.0
 pymupdf
-cbor2>=5.6.0
+# cbor2 6.x は pycardano (cbor2pure) と非互換のため 5.x に固定
+cbor2>=5.6.0,<6.0
 pynacl>=1.5.0
 starlette>=0.36.0
+# Phase 3: サーバサイドで Cardano tx を構築 (委任 / 投票)。0.19+ で Conway era 安定
+pycardano>=0.19.0
+# Reflex カスタムコンポーネント (ウォレット連携 UI) — ローカル editable
+-e cardanoism/custom_components/cardanoism_wallet


### PR DESCRIPTION
- cron 実行ユーザー / パスを btism 環境 (/home/btism/cardanoism_tmp) に更新
- requirements.txt に pycardano>=0.19.0 と ローカル editable の cardanoism-wallet を追加
  (pyproject.toml にあったが requirements.txt に欠落しており、pip install -r で入らず
  アプリ起動が ModuleNotFoundError: pycardano で失敗していた)
- cbor2 を <6.0 にピン (pycardano の cbor2pure 非互換回避)
- systemd unit ドキュメント修正:
  - ogmios-listener.service の Requires=ogmios.service を削除
    (Ogmios を別サーバで動かす構成だと Unit not found で起動失敗するため)
  - ga-ai-worker.service を ogmios-listener.service と同じ書式に統一