### PR TITLE
委任先名のリアルタイム更新 / 新規ユーザー言語 / ライブポーリング切断検知

### DIFF
--- a/cardanoism/backend/auth_db.py
+++ b/cardanoism/backend/auth_db.py
@@ -84,13 +84,17 @@ def update_user_profile(
         conn.commit()
 
 
-def _create_user(cursor, conn, username: str, avatar_url: str, email: str) -> int:
+def _create_user(cursor, conn, username: str, avatar_url: str, email: str,
+                 language: str = "ja") -> int:
     """users テーブルに新規ユーザーを作成して user_id を返す内部ヘルパー。
     external_uuid (UUID v4) を同時に発行する。
+    language はサインアップ時のブラウザ判定言語 ('ja' / 'en')。
     """
+    lang = language if language in ("ja", "en") else "ja"
     cursor.execute(
-        "INSERT INTO users (username, email, avatar_url, external_uuid) VALUES (?, ?, ?, ?)",
-        (username, email or None, avatar_url or None, str(uuid.uuid4())),
+        "INSERT INTO users (username, email, avatar_url, external_uuid, language) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (username, email or None, avatar_url or None, str(uuid.uuid4()), lang),
     )
     conn.commit()
     user_id = cursor.lastrowid
@@ -113,11 +117,13 @@ def get_or_create_user_by_provider(
     username: str,
     avatar_url: str = "",
     email: str = "",
+    language: str = "ja",
 ) -> dict:
     """
     provider/provider_id でユーザーを取得または新規作成する。
     LINE ログイン時は LINE 通知チャンネルも自動作成する。
     Google ログイン時はメール通知チャンネルも自動作成する。
+    language は新規作成時の users.language 初期値 (既存ユーザーには影響しない)。
     """
     with get_db() as (cursor, conn):
         # 既存プロバイダ検索
@@ -138,7 +144,7 @@ def get_or_create_user_by_provider(
             return existing
 
         # 新規ユーザー作成
-        user_id = _create_user(cursor, conn, username, avatar_url, email)
+        user_id = _create_user(cursor, conn, username, avatar_url, email, language)
 
         # プロバイダ紐付け
         cursor.execute(

--- a/cardanoism/backend/auth_state.py
+++ b/cardanoism/backend/auth_state.py
@@ -73,43 +73,47 @@ _OAUTH_STATE_SECRET = (
 _OAUTH_STATE_TTL_SECONDS = 600  # 10 分以内のコールバックのみ受け付ける
 
 
-def _make_signed_state(provider: str, mode: str = "login") -> str:
-    """形式: provider.mode.timestamp.nonce.signature
+def _make_signed_state(provider: str, mode: str = "login", lang: str = "ja") -> str:
+    """形式: provider.mode.lang.timestamp.nonce.signature
 
     HMAC-SHA256 で署名するためサーバ State を持たずに検証可能。
+    lang はログインボタン押下時点のブラウザ判定言語。新規ユーザー作成時の
+    users.language 初期値に使う (OAuth コールバックは別ページロードで
+    ブラウザ言語判定が間に合わないため、state に持たせて引き継ぐ)。
     """
     timestamp = int(_time.time())
     nonce = secrets.token_urlsafe(8)
-    payload = f"{provider}.{mode}.{timestamp}.{nonce}"
+    lang = lang if lang in ("ja", "en") else "ja"
+    payload = f"{provider}.{mode}.{lang}.{timestamp}.{nonce}"
     sig = hmac.new(
         _OAUTH_STATE_SECRET.encode(), payload.encode(), hashlib.sha256
     ).hexdigest()[:16]
     return f"{payload}.{sig}"
 
 
-def _verify_signed_state(state: str, expected_provider: str) -> tuple[bool, str]:
-    """state を検証。戻り値: (valid, mode)。失敗時は (False, "")。"""
+def _verify_signed_state(state: str, expected_provider: str) -> tuple[bool, str, str]:
+    """state を検証。戻り値: (valid, mode, lang)。失敗時は (False, "", "")。"""
     if not state:
-        return False, ""
+        return False, "", ""
     parts = state.split(".")
-    if len(parts) != 5:
-        return False, ""
-    provider, mode, ts_str, nonce, sig = parts
+    if len(parts) != 6:
+        return False, "", ""
+    provider, mode, lang, ts_str, nonce, sig = parts
     if provider != expected_provider:
-        return False, ""
+        return False, "", ""
     try:
         ts = int(ts_str)
     except ValueError:
-        return False, ""
+        return False, "", ""
     if int(_time.time()) - ts > _OAUTH_STATE_TTL_SECONDS:
-        return False, ""
-    payload = f"{provider}.{mode}.{ts}.{nonce}"
+        return False, "", ""
+    payload = f"{provider}.{mode}.{lang}.{ts}.{nonce}"
     expected_sig = hmac.new(
         _OAUTH_STATE_SECRET.encode(), payload.encode(), hashlib.sha256
     ).hexdigest()[:16]
     if not hmac.compare_digest(sig, expected_sig):
-        return False, ""
-    return True, mode
+        return False, "", ""
+    return True, mode, lang
 
 
 def _derive_twitter_verifier_from_nonce(nonce: str) -> str:
@@ -126,14 +130,16 @@ def _derive_twitter_verifier_from_nonce(nonce: str) -> str:
     return base64.urlsafe_b64encode(seed).rstrip(b"=").decode()  # 43 chars (RFC 7636)
 
 
-def _make_twitter_state_and_verifier() -> tuple[str, str]:
+def _make_twitter_state_and_verifier(lang: str = "ja") -> tuple[str, str]:
     """Twitter login 開始時の (state, code_verifier) を生成。
 
     state は signed state (provider=twitter)、verifier は nonce から派生。
+    lang はブラウザ判定言語 (新規ユーザーの初期言語に使う)。
     """
     timestamp = int(_time.time())
     nonce = secrets.token_urlsafe(16)
-    payload = f"twitter.login.{timestamp}.{nonce}"
+    lang = lang if lang in ("ja", "en") else "ja"
+    payload = f"twitter.login.{lang}.{timestamp}.{nonce}"
     sig = hmac.new(
         _OAUTH_STATE_SECRET.encode(), payload.encode(), hashlib.sha256
     ).hexdigest()[:16]
@@ -142,19 +148,19 @@ def _make_twitter_state_and_verifier() -> tuple[str, str]:
     return state, verifier
 
 
-def _verify_twitter_state(state: str) -> tuple[bool, str]:
+def _verify_twitter_state(state: str) -> tuple[bool, str, str]:
     """state を検証し、対応する code_verifier を返す。
 
-    戻り値: (valid, code_verifier)。失敗時は (False, "")。
+    戻り値: (valid, code_verifier, lang)。失敗時は (False, "", "")。
     """
-    valid, _mode = _verify_signed_state(state, "twitter")
+    valid, _mode, lang = _verify_signed_state(state, "twitter")
     if not valid:
-        return False, ""
+        return False, "", ""
     parts = state.split(".")
-    if len(parts) != 5:
-        return False, ""
-    nonce = parts[3]
-    return True, _derive_twitter_verifier_from_nonce(nonce)
+    if len(parts) != 6:
+        return False, "", ""
+    nonce = parts[4]  # provider.mode.lang.ts.nonce.sig
+    return True, _derive_twitter_verifier_from_nonce(nonce), lang
 
 
 class AuthState(rx.State):
@@ -505,7 +511,7 @@ class AuthState(rx.State):
 
     def start_line_login(self):
         """LINE認証ページへリダイレクトする。"""
-        state_param = _make_signed_state("line", "login")
+        state_param = _make_signed_state("line", "login", self.language)
 
         auth_url = (
             "https://access.line.me/oauth2/v2.1/authorize"
@@ -524,7 +530,7 @@ class AuthState(rx.State):
         if not self.is_logged_in:
             self.show_login_modal = True
             return
-        state_param = _make_signed_state("line", "connect")
+        state_param = _make_signed_state("line", "connect", self.language)
 
         auth_url = (
             "https://access.line.me/oauth2/v2.1/authorize"
@@ -553,7 +559,7 @@ class AuthState(rx.State):
             return rx.redirect("/login?error=line_denied")
 
         # HMAC 署名 state を検証 (Reflex State 不要なので WebView 切替でも壊れない)
-        valid, oauth_mode = _verify_signed_state(state, "line")
+        valid, oauth_mode, oauth_lang = _verify_signed_state(state, "line")
         if not valid:
             logger.warning("LINE OAuth state invalid (HMAC mismatch or expired): %s", state[:24])
             # mode 不明なので login 側にリダイレクト（connect 失敗もほぼここ）
@@ -630,7 +636,9 @@ class AuthState(rx.State):
 
         # ── login モード: ユーザー取得 or 作成 ──
         try:
-            user = get_or_create_user_by_provider("line", line_id, display_name, picture_url)
+            user = get_or_create_user_by_provider(
+                "line", line_id, display_name, picture_url, language=oauth_lang,
+            )
         except Exception as e:
             logger.error("DB error: %s", e)
             return rx.redirect("/login?error=db_error")
@@ -695,7 +703,7 @@ class AuthState(rx.State):
 
     def start_google_login(self):
         """Google認証ページへリダイレクトする。"""
-        state_param = _make_signed_state("google", "login")
+        state_param = _make_signed_state("google", "login", self.language)
 
         auth_url = (
             "https://accounts.google.com/o/oauth2/v2/auth"
@@ -722,7 +730,7 @@ class AuthState(rx.State):
         if error:
             return rx.redirect("/login?error=google_denied")
 
-        valid, _mode = _verify_signed_state(state, "google")
+        valid, _mode, oauth_lang = _verify_signed_state(state, "google")
         if not valid:
             logger.warning("Google OAuth state invalid (HMAC mismatch or expired): %s", state[:24])
             return rx.redirect("/login?error=state_mismatch")
@@ -773,7 +781,9 @@ class AuthState(rx.State):
             return rx.redirect("/login?error=no_user_id")
 
         try:
-            user = get_or_create_user_by_provider("google", google_id, display_name, picture_url, email)
+            user = get_or_create_user_by_provider(
+                "google", google_id, display_name, picture_url, email, language=oauth_lang,
+            )
         except Exception as e:
             logger.error("DB error: %s", e)
             return rx.redirect("/login?error=db_error")
@@ -797,7 +807,7 @@ class AuthState(rx.State):
         state と code_verifier を HMAC で導出するため、Reflex State に
         頼らず (= モバイル WebView 切替に耐える) PKCE が成立する。
         """
-        state, code_verifier = _make_twitter_state_and_verifier()
+        state, code_verifier = _make_twitter_state_and_verifier(self.language)
         code_challenge = base64.urlsafe_b64encode(
             hashlib.sha256(code_verifier.encode()).digest()
         ).rstrip(b"=").decode()
@@ -829,7 +839,7 @@ class AuthState(rx.State):
         if error:
             return rx.redirect("/login?error=twitter_denied")
 
-        valid, code_verifier = _verify_twitter_state(state)
+        valid, code_verifier, oauth_lang = _verify_twitter_state(state)
         if not valid:
             logger.warning("Twitter OAuth state invalid (HMAC mismatch or expired): %s", state[:24])
             return rx.redirect("/login?error=state_mismatch")
@@ -886,7 +896,9 @@ class AuthState(rx.State):
             return rx.redirect("/login?error=no_user_id")
 
         try:
-            user = get_or_create_user_by_provider("twitter", twitter_id, display_name, picture_url)
+            user = get_or_create_user_by_provider(
+                "twitter", twitter_id, display_name, picture_url, language=oauth_lang,
+            )
         except Exception as e:
             logger.error("DB error: %s", e)
             return rx.redirect("/login?error=db_error")

--- a/cardanoism/backend/listener_stake.py
+++ b/cardanoism/backend/listener_stake.py
@@ -12,9 +12,13 @@ Ogmios listener から呼ばれる委任 cert の DB 直書きハンドラ (Phas
 書き込み: stake_addresses テーブルの該当ユーザー行のみ (address カラム一致時)。
 listener は無関係チェーンの委任を DB に流し込まない (= ユーザー所有データに限定)。
 
+delegated_pool_name / delegated_drep_name は cert に含まれないが、ユーザー登録
+アドレスが委任したときだけ Koios で名前を即解決して埋める (ダッシュボードに
+旧名が残らないようにするため)。名前解決は affected 行があったときのみ実行する
+ので、無関係チェーンの委任で Koios を叩くことはない。
+
 非対象 (Koios sync 担当):
   - role / role_checked_at の正確な確定 (DRep / abstain / delegator) は detect_stake_role が後追い
-  - delegated_pool_name / delegated_drep_name (この cert からは取れないので Koios sync で埋める)
 """
 from __future__ import annotations
 
@@ -92,6 +96,26 @@ def _resolve_drep_target(drep_obj: Any) -> str | _NoChange | None:
     return drep_id
 
 
+def _resolve_pool_name(pool_id: str) -> str:
+    """pool_id (bech32) からプール名を Koios で解決。失敗時は空文字。"""
+    try:
+        from cardanoism.backend.koios import get_pool_name
+        return get_pool_name(pool_id) or ""
+    except Exception as e:  # noqa: BLE001
+        logger.warning("listener: pool 名解決失敗 %s: %s", pool_id, e)
+        return ""
+
+
+def _resolve_drep_name(drep_id: str) -> str:
+    """drep_id (bech32) から DRep 名を Koios で解決。失敗時は空文字。"""
+    try:
+        from cardanoism.backend.koios import _fetch_drep_name
+        return _fetch_drep_name(drep_id) or ""
+    except Exception as e:  # noqa: BLE001
+        logger.warning("listener: drep 名解決失敗 %s: %s", drep_id, e)
+        return ""
+
+
 def _update_stake_delegation(
     stake_addr: str,
     *,
@@ -104,7 +128,10 @@ def _update_stake_delegation(
     pool_id / drep_id のうち _NO_CHANGE は触らない。
     None を渡すと NULL に設定される (Always Abstain 等の特殊値)。
 
-    戻り値: 影響行数 > 0 (= ユーザー登録済みアドレスだった) なら True。
+    影響行があった (= ユーザー登録済みアドレス) 場合は、続けて
+    delegated_pool_name / delegated_drep_name も Koios で解決して更新する。
+
+    戻り値: 影響行数 > 0 なら True。
     """
     sets = ["last_event_slot = ?", "role_checked_at = NOW()"]
     params: list = [int(slot)]
@@ -123,7 +150,34 @@ def _update_stake_delegation(
         )
         affected = cursor.rowcount or 0
         conn.commit()
-    return affected > 0
+
+    if affected <= 0:
+        return False
+
+    # ユーザー登録アドレスだったので名前も即時解決して更新する。
+    # (cert に名前は含まれないため Koios で引く。委任イベントは稀なのでコスト許容)
+    name_sets: list[str] = []
+    name_params: list = []
+    if pool_id is not _NO_CHANGE and pool_id:
+        name_sets.append("delegated_pool_name = ?")
+        name_params.append(_resolve_pool_name(pool_id) or None)
+    if drep_id is not _NO_CHANGE:
+        name_sets.append("delegated_drep_name = ?")
+        # drep_id が None (Always Abstain 等) なら名前も NULL
+        name_params.append(_resolve_drep_name(drep_id) or None if drep_id else None)
+    if name_sets:
+        name_params.append(stake_addr)
+        try:
+            with get_db() as (cursor, conn):
+                cursor.execute(
+                    f"UPDATE stake_addresses SET {', '.join(name_sets)} WHERE address = ?",
+                    name_params,
+                )
+                conn.commit()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("listener: 委任先名の更新失敗 stake=%s: %s", stake_addr[:30], e)
+
+    return True
 
 
 # ─── Cert ハンドラ ─────────────────────────────────────────

--- a/cardanoism/pages/staking.py
+++ b/cardanoism/pages/staking.py
@@ -38,6 +38,26 @@ MAX_BLOCK_TOTAL_SIZE_BYTES = 91_212
 logger = logging.getLogger(__name__)
 
 
+def _is_client_connected(client_token: str) -> bool:
+    """client_token のクライアントがまだ WebSocket 接続中かを返す。
+
+    バックグラウンドポーリングの終了判定に使う。Reflex の EventNamespace は
+    接続中クライアントを token_to_sid に保持しており、切断時に削除される。
+    判定不能なとき (内部 API 差異・Redis 構成等) は True を返し、誤ってループを
+    止めないようにする。
+    """
+    if not client_token:
+        return True
+    try:
+        from reflex.utils.prerequisites import get_app
+        ns = get_app().app.event_namespace
+        if ns is None:
+            return True
+        return client_token in ns.token_to_sid
+    except Exception:
+        return True
+
+
 # ─── State ────────────────────────────────────────────────────────────────────
 
 
@@ -474,10 +494,18 @@ class StakingDashboardState(rx.State):
             if self.polling:
                 return
             self.polling = True
+            client_token = self.router.session.client_token
         try:
             while True:
                 try:
                     await asyncio.sleep(1)
+                    # クライアント切断検知: ブラウザを閉じる / 別ページへ移動すると
+                    # WebSocket が切れる。これを検知せず while True を回し続けると
+                    # 「disconnected client」警告 + DB/Koios を叩き続けるリソース
+                    # リークになる。切断していたらループを終了する。
+                    if not _is_client_connected(client_token):
+                        logger.info("start_live_polling: クライアント切断を検知、ポーリング停止")
+                        break
                     async with self:
                         self._fetch_live_blocks()
                 except asyncio.CancelledError:


### PR DESCRIPTION
- listener: 委任 cert 検知時に委任先名 (delegated_pool_name / delegated_drep_name)
  も Koios で即解決。これまで ID は即時更新でも名前は cron 任せで最大 15 分古い
  まま残っていた
- auth: 新規ユーザーの users.language が常に DB デフォルト 'ja' で作成されていた
  問題を修正。OAuth state パラメータにブラウザ判定言語を埋め込んで引き継ぎ、
  英語ブラウザのユーザーは英語で登録される
- staking: ライブポーリング (start_live_polling) にクライアント切断検知を追加。
  while True で離脱後もループが永久に回り「disconnected client」警告 +
  DB/Koios を叩き続けるリソースリークになっていた