### PR TITLE
fix(db): get_db() の finally で rollback しプール接続の凍結スナップショットを解放

### DIFF
--- a/cardanoism/backend/db_connect.py
+++ b/cardanoism/backend/db_connect.py
@@ -87,12 +87,24 @@ def dbConnect():
 
 @contextmanager
 def get_db():
-    """Context manager that yields (cursor, conn) and always closes them."""
+    """Context manager that yields (cursor, conn) and always closes them.
+
+    finally で rollback してからプールに返す。MariaDB の既定は autocommit=False +
+    REPEATABLE READ なので、SELECT した瞬間にトランザクションが暗黙開始され一貫
+    スナップショットを握り続ける。読み取り専用パスは commit/rollback しないため、
+    その接続を再利用すると古いスナップショットを見続け、他セッションの変更
+    （手動 DB 編集など）が永遠に反映されない。rollback でスナップショットを解放する。
+    書き込みパスは既に commit 済みなのでこの rollback は no-op。
+    """
     cursor, conn = dbConnect()
     try:
         yield cursor, conn
     finally:
         try:
+            try:
+                conn.rollback()
+            except mariadb.Error:
+                pass
             cursor.close()
         finally:
             conn.close()

--- a/deploy/cron.d-cardanoism-notify
+++ b/deploy/cron.d-cardanoism-notify
@@ -48,6 +48,12 @@ LOG=/home/btism/cardanoism_log
 # Active GA の投票集計を最新化 (pre_ratify トリガーの前提)
 */15 * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event summary_sync >> $LOG/notify-summary_sync.log 2>&1
 
+# GA 本体の取り込み (Koios /proposal_list 全件 upsert)。
+# listener が骨組み行を作るが title/abstract/type 等は Koios 由来。Koios が
+# index した直後に値が backfill されるよう高頻度で回す。Koios 呼び出しは
+# /proposal_list 1 リクエストのみで軽量。--no-translate なので *_ja は触らない。
+*/15 * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY cardanoism/backend/governance.py --no-translate >> $LOG/notify-governance.log 2>&1
+
 # ── オフチェーン同期 (常時) ──────────────────────────────
 # 法定通貨レート (CoinGecko)
 */5  * * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event fiat_sync           >> $LOG/notify-fiat_sync.log 2>&1
@@ -64,8 +70,7 @@ LOG=/home/btism/cardanoism_log
 # ── フォールバック (listener 停止対策、24 時間に 1 回深夜) ─────
 # 通常は Ogmios listener が epoch_start を検知してこれらを発火するが、
 # listener が落ちている間でもデータが完全停止しないよう 1 日 1 回バックアップ実行。
-# (summary_sync は常時 15min 実行済みなので fallback には含めない)
-0    3 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY cardanoism/backend/governance.py --no-translate >> $LOG/notify-governance.log 2>&1
+# (summary_sync / governance.py は常時 15min 実行済みなので fallback には含めない)
 30   3 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event params_sync             >> $LOG/notify-params_sync.log 2>&1
 0    4 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event treasury_sync           >> $LOG/notify-treasury_sync.log 2>&1
 30   4 * * *  btism cd $WORKDIR && infisical run --env=$ENV -- $PY notify_worker.py --event drep_sync               >> $LOG/notify-drep_sync.log 2>&1


### PR DESCRIPTION
MariaDB 既定の autocommit=False + REPEATABLE READ では、SELECT 時に暗黙開始 されたトランザクションが一貫スナップショットを握り続ける。読み取り専用パスは
commit/rollback しないため、その接続を再利用すると古いスナップショットを見続け、
他セッションの変更 (手動 DB 編集 / cron sync の書き込み) が反映されない。
finally で rollback してからプールに返すことで毎回スナップショットを解放する。

あわせて governance.py の Koios /proposal_list 取り込み cron を日次 fallback から 15 分間隔の常時実行に変更。listener 検知後、Koios が index 次第すぐ欠損値
(title/abstract/type/投票率の前提行) が backfill されるようにする。