### PR TITLE
ui(drep-match): バーの軸を反転 (左=賛成 / 右=反対)

### DIFF
--- a/cardanoism/pages/governance_drep.py
+++ b/cardanoism/pages/governance_drep.py
@@ -1240,12 +1240,13 @@ def _quiz_view() -> rx.Component:
                 width="100%",
             ),
             # 5 段階 Likert agree/disagree (universal labels)
+            # 左 = 強く賛成 → 右 = 強く反対 で表示 (UI 表示順のみ。値はそのまま)
             rx.hstack(
-                _choice_button(1, "drep_match_answer_strongly_disagree", "amber"),
-                _choice_button(2, "drep_match_answer_slightly_disagree", "soft_amber"),
-                _choice_button(3, "drep_match_answer_neutral",           "gray"),
-                _choice_button(4, "drep_match_answer_slightly_agree",    "soft_amber"),
                 _choice_button(5, "drep_match_answer_strongly_agree",    "amber"),
+                _choice_button(4, "drep_match_answer_slightly_agree",    "soft_amber"),
+                _choice_button(3, "drep_match_answer_neutral",           "gray"),
+                _choice_button(2, "drep_match_answer_slightly_disagree", "soft_amber"),
+                _choice_button(1, "drep_match_answer_strongly_disagree", "amber"),
                 spacing="2", wrap="wrap", justify="center", width="100%", padding_y="6px",
             ),
             # 賛成派の主張 / 反対派の主張 (v4) - 横並びだがモバイルは縦に wrap

--- a/cardanoism/pages/governance_drep_detail.py
+++ b/cardanoism/pages/governance_drep_detail.py
@@ -260,7 +260,9 @@ class DrepDetailState(rx.State):
                     return "mid"
                 return "low"
 
-            # 7 axis 全てを 1 つのスライダー型行で表示 (v2 設計、対立軸/独立軸の区別なし)
+            # 8 axis をスライダー型行で表示。
+            # UI 表示順は「左 = 賛成 (score 高) / 右 = 反対 (score 低)」で反転。
+            # データの意味 (score 1.0 = Yes 寄り) は保持し、表示位置だけ swap。
             balance_rows: list[dict[str, str]] = []
             single_rows: list[dict[str, str]] = []
             for axis in _COMPASS_AXES:
@@ -268,9 +270,11 @@ class DrepDetailState(rx.State):
                 conf_val = _conf(axis)
                 offset = score - 0.5
                 if offset > 0.02:
+                    # 賛成寄り → 左側に dot。フローティングラベルは _right (= 賛成側ラベル)
                     side = "pos"
                     side_label_key = f"drep_match_axis_{axis}_right"
                 elif offset < -0.02:
+                    # 反対寄り → 右側に dot。フローティングラベルは _left (= 反対側ラベル)
                     side = "neg"
                     side_label_key = f"drep_match_axis_{axis}_left"
                 else:
@@ -280,13 +284,15 @@ class DrepDetailState(rx.State):
                     "kind":             "balance",
                     "key":              axis,
                     "label_key":        f"drep_match_axis_{axis}",
-                    "left_label_key":   f"drep_match_axis_{axis}_left",
-                    "right_label_key":  f"drep_match_axis_{axis}_right",
+                    # 左 = 賛成側ラベル (_right) / 右 = 反対側ラベル (_left) で swap
+                    "left_label_key":   f"drep_match_axis_{axis}_right",
+                    "right_label_key":  f"drep_match_axis_{axis}_left",
                     "side":             side,
                     "side_label_key":   side_label_key,
                     "side_desc_key":    f"drep_match_axis_{axis}_desc",
                     "magnitude_pct":    f"{abs(offset) * 200:.0f}",
-                    "dot_pos_pct":      f"{score * 100:.0f}",
+                    # 位置反転: score 1.0 (賛成) を左端 0%、score 0.0 (反対) を右端 100%
+                    "dot_pos_pct":      f"{(1.0 - score) * 100:.0f}",
                     "conf_class":       _conf_class(conf_val),
                 })
             self.compass_balance_rows = balance_rows


### PR DESCRIPTION
- マッチング診断 Likert ボタン: level 5(強く賛成) → 1(強く反対) の順に表示
- DRep 詳細 投票傾向スライダー:
  - dot 位置を (1 - score) * 100% に反転
  - left_label と right_label を swap
  - フローティングラベルの side_label_key 判定は元の意味のまま (offset > 0 = 賛成寄り → _right ラベル「積極」が左に表示される)

データ層は無変更 (answer_to_value / profile_json score の意味は保持)。 UI 表示順のみ反転。