### PR TITLE
fix(koios)+ui+feat(favorites): 429 対策 / 詳細ページ UI 統一 / お気に入り CSV エクスポート

### DIFF
--- a/cardanoism/backend/auth_db.py
+++ b/cardanoism/backend/auth_db.py
@@ -611,8 +611,8 @@ def get_ga_favorites(user_id: int) -> list:
 
 def get_governance_favorites_for_export(user_id: int) -> list[dict]:
     """ガバナンスお気に入りの CSV エクスポート用データ。
-    TreasuryWithdrawals の場合は ga_withdrawal_payout から引き出し合計 (Lovelace)
-    を集計して withdrawal_lovelace に格納する。
+    TreasuryWithdrawals の場合は governance_actions.withdrawal_total_lovelace
+    を引き出し合計として返す (全 status の GA で利用可能)。
     """
     with get_db() as (cursor, _):
         cursor.execute(
@@ -621,10 +621,7 @@ def get_governance_favorites_for_export(user_id: int) -> list[dict]:
                    g.title, g.title_ja, g.proposal_type,
                    g.proposed_epoch, g.ratified_epoch, g.enacted_epoch,
                    g.dropped_epoch, g.expired_epoch,
-                   (SELECT COALESCE(SUM(amount_lovelace), 0)
-                      FROM ga_withdrawal_payout
-                     WHERE proposal_id COLLATE utf8mb4_unicode_ci
-                         = g.proposal_id COLLATE utf8mb4_unicode_ci) AS withdrawal_lovelace
+                   g.withdrawal_total_lovelace AS withdrawal_lovelace
               FROM favorites f
               JOIN governance_actions g ON f.proposal_uuid = g.proposal_id
              WHERE f.user_id = ? AND f.type = 'governance'

--- a/cardanoism/backend/auth_db.py
+++ b/cardanoism/backend/auth_db.py
@@ -609,6 +609,31 @@ def get_ga_favorites(user_id: int) -> list:
         return [dict(row) for row in cursor.fetchall()]
 
 
+def get_governance_favorites_for_export(user_id: int) -> list[dict]:
+    """ガバナンスお気に入りの CSV エクスポート用データ。
+    TreasuryWithdrawals の場合は ga_withdrawal_payout から引き出し合計 (Lovelace)
+    を集計して withdrawal_lovelace に格納する。
+    """
+    with get_db() as (cursor, _):
+        cursor.execute(
+            """
+            SELECT f.proposal_uuid AS proposal_id, f.created_at AS favorited_at,
+                   g.title, g.title_ja, g.proposal_type,
+                   g.proposed_epoch, g.ratified_epoch, g.enacted_epoch,
+                   g.dropped_epoch, g.expired_epoch,
+                   (SELECT COALESCE(SUM(amount_lovelace), 0)
+                      FROM ga_withdrawal_payout
+                     WHERE proposal_id = g.proposal_id) AS withdrawal_lovelace
+              FROM favorites f
+              JOIN governance_actions g ON f.proposal_uuid = g.proposal_id
+             WHERE f.user_id = ? AND f.type = 'governance'
+             ORDER BY f.created_at DESC
+            """,
+            (user_id,),
+        )
+        return [dict(r) for r in cursor.fetchall()]
+
+
 def get_drep_favorites(user_id: int) -> list:
     """DRep お気に入り一覧 (dreps JOIN)。favorites.proposal_uuid には drep_id を保存。
     UI 側で `!= ""` 等で分岐するため、NULL は空文字に正規化して返す。
@@ -628,13 +653,14 @@ def get_drep_favorites(user_id: int) -> list:
         )
         return [
             {
-                "id":          int(r.get("id") or 0),
-                "drep_id":     str(r.get("drep_id") or ""),
-                "given_name":  str(r.get("given_name") or ""),
-                "image_url":   str(r.get("image_url") or ""),
-                "active":      "1" if r.get("active") else "",
-                "drep_status": str(r.get("drep_status") or ""),
-                "amount":      "" if r.get("amount") is None else str(r.get("amount")),
+                "id":            int(r.get("id") or 0),
+                "drep_id":       str(r.get("drep_id") or ""),
+                "given_name":    str(r.get("given_name") or ""),
+                "image_url":     str(r.get("image_url") or ""),
+                "active":        "1" if r.get("active") else "",
+                "drep_status":   str(r.get("drep_status") or ""),
+                "amount":        "" if r.get("amount") is None else str(r.get("amount")),
+                "favorited_at":  str(r.get("created_at") or ""),
             }
             for r in cursor.fetchall()
         ]
@@ -671,6 +697,7 @@ def get_pool_favorites(user_id: int) -> list:
                 "live_delegators": "" if r.get("live_delegators") is None else str(r.get("live_delegators")),
                 "pool_status":     str(r.get("pool_status") or ""),
                 "retiring_epoch":  "" if r.get("retiring_epoch") is None else str(r.get("retiring_epoch")),
+                "favorited_at":    str(r.get("created_at") or ""),
             }
             for r in cursor.fetchall()
         ]

--- a/cardanoism/backend/auth_db.py
+++ b/cardanoism/backend/auth_db.py
@@ -623,7 +623,8 @@ def get_governance_favorites_for_export(user_id: int) -> list[dict]:
                    g.dropped_epoch, g.expired_epoch,
                    (SELECT COALESCE(SUM(amount_lovelace), 0)
                       FROM ga_withdrawal_payout
-                     WHERE proposal_id = g.proposal_id) AS withdrawal_lovelace
+                     WHERE proposal_id COLLATE utf8mb4_unicode_ci
+                         = g.proposal_id COLLATE utf8mb4_unicode_ci) AS withdrawal_lovelace
               FROM favorites f
               JOIN governance_actions g ON f.proposal_uuid = g.proposal_id
              WHERE f.user_id = ? AND f.type = 'governance'

--- a/cardanoism/backend/auth_state.py
+++ b/cardanoism/backend/auth_state.py
@@ -34,6 +34,7 @@ from cardanoism.backend.auth_db import (
     add_favorite,
     remove_favorite,
     get_ga_favorites,
+    get_governance_favorites_for_export,
     get_drep_favorites,
     get_pool_favorites,
     get_notification_settings,
@@ -1455,6 +1456,167 @@ class AuthState(rx.State):
     def pool_favorites_next_page(self):
         if self.pool_favorites_page < self.pool_favorites_total_pages:
             self.pool_favorites_page += 1
+
+    # ─── お気に入り CSV エクスポート ──────────────────────────────
+    # ヘッダーは英語キー、UTF-8 BOM 付きで Excel での日本語文字化けを防ぐ。
+
+    def _csv_response(self, headers: list[str], rows: list[list], filename: str):
+        import csv as _csv
+        import io as _io
+        buf = _io.StringIO()
+        writer = _csv.writer(buf, lineterminator="\r\n", quoting=_csv.QUOTE_MINIMAL)
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow(row)
+        # UTF-8 BOM を先頭に付与 (Excel 文字化け対策)
+        data = "﻿" + buf.getvalue()
+        return rx.download(data=data.encode("utf-8"), filename=filename)
+
+    def _today_str(self) -> str:
+        from datetime import datetime, timezone
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def _site_url(self) -> str:
+        import os as _os
+        return (_os.getenv("CARDANOISM_URL") or "https://cardanoism.com").rstrip("/")
+
+    def _status_from_epochs(self, ratified, enacted, dropped, expired) -> str:
+        if enacted:
+            return "enacted"
+        if ratified:
+            return "ratified"
+        if expired:
+            return "expired"
+        if dropped:
+            return "dropped"
+        return "active"
+
+    def export_catalyst_favorites_csv(self):
+        if not self.is_logged_in:
+            return
+        favs = get_favorites(self.user_id, "catalyst")
+        base = self._site_url()
+        headers = [
+            "uuid", "title", "title_ja", "fund", "status",
+            "amount_requested", "currency", "url", "favorited_at",
+        ]
+        rows = []
+        for f in favs:
+            uuid = str(f.get("proposal_uuid") or "")
+            rows.append([
+                uuid,
+                str(f.get("title") or ""),
+                str(f.get("title_ja") or ""),
+                str(f.get("fund_label") or ""),
+                str(f.get("funding_status") or ""),
+                str(f.get("amount_requested") if f.get("amount_requested") is not None else ""),
+                str(f.get("currency_symbol") or ""),
+                f"{base}/catalyst/proposals/{uuid}" if uuid else "",
+                str(f.get("created_at") or ""),
+            ])
+        return self._csv_response(
+            headers, rows, f"favorites_catalyst_{self._today_str()}.csv"
+        )
+
+    def export_governance_favorites_csv(self):
+        if not self.is_logged_in:
+            return
+        favs = get_governance_favorites_for_export(self.user_id)
+        base = self._site_url()
+        headers = [
+            "proposal_id", "title", "title_ja", "type", "proposed_epoch",
+            "status", "enacted_epoch", "withdrawal_ada", "url", "favorited_at",
+        ]
+        rows = []
+        for f in favs:
+            pid = str(f.get("proposal_id") or "")
+            withdrawal_lovelace = int(f.get("withdrawal_lovelace") or 0)
+            withdrawal_ada = ""
+            if withdrawal_lovelace > 0:
+                withdrawal_ada = f"{withdrawal_lovelace / 1_000_000:.6f}".rstrip("0").rstrip(".")
+            rows.append([
+                pid,
+                str(f.get("title") or ""),
+                str(f.get("title_ja") or ""),
+                str(f.get("proposal_type") or ""),
+                str(f.get("proposed_epoch") if f.get("proposed_epoch") is not None else ""),
+                self._status_from_epochs(
+                    f.get("ratified_epoch"), f.get("enacted_epoch"),
+                    f.get("dropped_epoch"), f.get("expired_epoch"),
+                ),
+                str(f.get("enacted_epoch") if f.get("enacted_epoch") is not None else ""),
+                withdrawal_ada,
+                f"{base}/governance/{pid}" if pid else "",
+                str(f.get("favorited_at") or ""),
+            ])
+        return self._csv_response(
+            headers, rows, f"favorites_governance_{self._today_str()}.csv"
+        )
+
+    def export_drep_favorites_csv(self):
+        if not self.is_logged_in:
+            return
+        favs = get_drep_favorites(self.user_id)
+        base = self._site_url()
+        headers = [
+            "drep_id", "given_name", "status", "amount_ada", "url", "favorited_at",
+        ]
+        rows = []
+        for f in favs:
+            drep_id = str(f.get("drep_id") or "")
+            amount_str = str(f.get("amount") or "")
+            try:
+                amount_ada = f"{int(amount_str) / 1_000_000:.6f}".rstrip("0").rstrip(".") if amount_str else ""
+            except (TypeError, ValueError):
+                amount_ada = ""
+            rows.append([
+                drep_id,
+                str(f.get("given_name") or ""),
+                str(f.get("drep_status") or ""),
+                amount_ada,
+                f"{base}/drep/{drep_id}" if drep_id else "",
+                str(f.get("favorited_at") or ""),
+            ])
+        return self._csv_response(
+            headers, rows, f"favorites_drep_{self._today_str()}.csv"
+        )
+
+    def export_pool_favorites_csv(self):
+        if not self.is_logged_in:
+            return
+        favs = get_pool_favorites(self.user_id)
+        base = self._site_url()
+        headers = [
+            "pool_id", "ticker", "pool_name", "live_stake_ada",
+            "live_saturation_pct", "live_delegators", "status",
+            "retiring_epoch", "url", "favorited_at",
+        ]
+        rows = []
+        for f in favs:
+            pool_id = str(f.get("pool_id") or "")
+            live_stake_str = str(f.get("live_stake") or "")
+            try:
+                live_stake_ada = (
+                    f"{int(live_stake_str) / 1_000_000:.6f}".rstrip("0").rstrip(".")
+                    if live_stake_str else ""
+                )
+            except (TypeError, ValueError):
+                live_stake_ada = ""
+            rows.append([
+                pool_id,
+                str(f.get("ticker") or ""),
+                str(f.get("pool_name") or ""),
+                live_stake_ada,
+                str(f.get("live_saturation") or ""),
+                str(f.get("live_delegators") or ""),
+                str(f.get("pool_status") or ""),
+                str(f.get("retiring_epoch") or ""),
+                f"{base}/staking/pool/{pool_id}" if pool_id else "",
+                str(f.get("favorited_at") or ""),
+            ])
+        return self._csv_response(
+            headers, rows, f"favorites_pool_{self._today_str()}.csv"
+        )
 
     @rx.var
     def filtered_pool_favorites(self) -> list[dict]:

--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -253,6 +253,8 @@ UI_JA: dict[str, str] = {
     "gov_id_copied": "提案 ID をコピーしました",
     "gov_stake_copied": "ステークアドレスをコピーしました",
     "gov_ref_no_label": "（ラベルなし）",
+    "drep_url_copied": "DRepページのリンクをコピーしました",
+    "pool_url_copied": "プールページのリンクをコピーしました",
 
     # ガバナンス サブナビゲーション
     "gov_subnav_why": "ガバナンスとは？",
@@ -1990,6 +1992,8 @@ UI_EN: dict[str, str] = {
     "gov_id_copied": "Proposal ID copied",
     "gov_stake_copied": "Stake address copied",
     "gov_ref_no_label": "(No label)",
+    "drep_url_copied": "DRep page link copied",
+    "pool_url_copied": "Pool page link copied",
 
     # Governance subnav
     "gov_subnav_why": "Why participate?",

--- a/cardanoism/backend/i18n.py
+++ b/cardanoism/backend/i18n.py
@@ -1677,6 +1677,7 @@ UI_JA: dict[str, str] = {
     "favorites_empty": "お気に入りはありません",
     "favorites_drep_empty": "DRep のお気に入りはまだありません",
     "favorites_pool_empty": "ステークプールのお気に入りはまだありません",
+    "favorites_export_csv": "CSV エクスポート",
 
     # プロフィールタブ
     "display_name": "表示名",
@@ -3394,6 +3395,7 @@ UI_EN: dict[str, str] = {
     "favorites_empty": "No favorites yet",
     "favorites_drep_empty": "No favorite DReps yet",
     "favorites_pool_empty": "No favorite stake pools yet",
+    "favorites_export_csv": "Export CSV",
 
     # Profile tab
     "display_name": "Display Name",

--- a/cardanoism/pages/governance_drep_detail.py
+++ b/cardanoism/pages/governance_drep_detail.py
@@ -381,7 +381,7 @@ def _drep_share_btn() -> rx.Component:
     return rx.menu.root(
         rx.menu.trigger(
             rx.icon(
-                "share-2", size=22, color="var(--gray-11)",
+                "share-2", size=26, color="var(--gray-11)",
                 cursor="pointer", padding="4px",
             ),
         ),

--- a/cardanoism/pages/governance_drep_detail.py
+++ b/cardanoism/pages/governance_drep_detail.py
@@ -376,33 +376,56 @@ def _breadcrumb() -> rx.Component:
 
 
 def _drep_share_btn() -> rx.Component:
-    """DRep ページの URL をクリップボードへコピーするシェアボタン。"""
-    return rx.el.button(
-        rx.icon("share-2", size=18, color="var(--gray-11)"),
-        on_click=[
-            rx.set_clipboard("https://cardanoism.com/drep/" + DrepDetailState.display_drep_id),
-            rx.toast(
-                AuthState.t["drep_url_copied"],
-                position="top-center",
-                style={
-                    "background-color": "var(--indigo-11)",
-                    "color": "white",
-                    "border-radius": "0.5rem",
-                },
+    """DRep ページのシェアメニュー (X / LINE / URL コピー)。
+    ガバナンス提案モーダルのシェアボタンと同じ挙動。"""
+    return rx.menu.root(
+        rx.menu.trigger(
+            rx.icon(
+                "share-2", size=22, color="var(--gray-11)",
+                cursor="pointer", padding="4px",
             ),
-        ],
-        cursor="pointer",
-        style={
-            "display":       "inline-flex",
-            "alignItems":    "center",
-            "border":        "none",
-            "background":    "transparent",
-            "padding":       "6px",
-            "borderRadius":  "8px",
-            "transition":    "background 0.15s",
-            "flexShrink":    "0",
-        },
-        _hover={"background": "var(--gray-3)"},
+        ),
+        rx.menu.content(
+            rx.menu.item(
+                "X (Twitter)",
+                on_click=rx.call_script(
+                    "const t = document.querySelector('.drep-title')?.innerText ?? '';"
+                    "const url = 'https://x.com/intent/tweet'"
+                    "  + '?text=' + encodeURIComponent(t)"
+                    "  + '&url=' + encodeURIComponent(window.location.href);"
+                    "window.open(url,'x-share',"
+                    "'width=550,height=420,menubar=no,toolbar=no,"
+                    "location=no,status=no,resizable=yes,scrollbars=yes');"
+                ),
+            ),
+            rx.menu.item(
+                "LINE",
+                on_click=rx.call_script(
+                    "const t = document.querySelector('.drep-title')?.innerText ?? '';"
+                    "const url = 'https://social-plugins.line.me/lineit/share'"
+                    "  + '?url=' + encodeURIComponent(window.location.href)"
+                    "  + '&text=' + encodeURIComponent(t);"
+                    "window.open(url,'line-share',"
+                    "'width=520,height=520,menubar=no,toolbar=no,"
+                    "location=no,status=no,resizable=yes,scrollbars=yes');"
+                ),
+            ),
+            rx.menu.item(
+                AuthState.t["proposal_copy_url"],
+                on_click=[
+                    rx.call_script("navigator.clipboard.writeText(window.location.href);"),
+                    rx.toast(
+                        AuthState.t["drep_url_copied"],
+                        position="top-center",
+                        style={
+                            "background-color": "var(--indigo-11)",
+                            "color": "white",
+                            "border-radius": "0.5rem",
+                        },
+                    ),
+                ],
+            ),
+        ),
     )
 
 
@@ -448,8 +471,10 @@ def _profile_card() -> rx.Component:
     )
     name_text = rx.cond(
         DrepDetailState.given_name != "",
-        rx.text(DrepDetailState.given_name, size="6", weight="bold", color="var(--gray-12)"),
-        rx.text(AuthState.t["drep_no_name"], size="6", weight="bold", color="var(--gray-10)"),
+        rx.text(DrepDetailState.given_name, size="6", weight="bold",
+                color="var(--gray-12)", class_name="drep-title"),
+        rx.text(AuthState.t["drep_no_name"], size="6", weight="bold",
+                color="var(--gray-10)", class_name="drep-title"),
     )
     fiat = rx.cond(
         AuthState.language == "en",

--- a/cardanoism/pages/governance_drep_detail.py
+++ b/cardanoism/pages/governance_drep_detail.py
@@ -375,6 +375,54 @@ def _breadcrumb() -> rx.Component:
     )
 
 
+def _drep_share_btn() -> rx.Component:
+    """DRep ページの URL をクリップボードへコピーするシェアボタン。"""
+    return rx.el.button(
+        rx.icon("share-2", size=18, color="var(--gray-11)"),
+        on_click=[
+            rx.set_clipboard("https://cardanoism.com/drep/" + DrepDetailState.display_drep_id),
+            rx.toast(
+                AuthState.t["drep_url_copied"],
+                position="top-center",
+                style={
+                    "background-color": "var(--indigo-11)",
+                    "color": "white",
+                    "border-radius": "0.5rem",
+                },
+            ),
+        ],
+        cursor="pointer",
+        style={
+            "display":       "inline-flex",
+            "alignItems":    "center",
+            "border":        "none",
+            "background":    "transparent",
+            "padding":       "6px",
+            "borderRadius":  "8px",
+            "transition":    "background 0.15s",
+            "flexShrink":    "0",
+        },
+        _hover={"background": "var(--gray-3)"},
+    )
+
+
+def _drep_fav_btn() -> rx.Component:
+    """DRep お気に入り (ハート) トグルボタン。"""
+    return rx.box(
+        rx.cond(
+            AuthState.drep_favorite_ids.contains(DrepDetailState.display_drep_id),
+            rx.icon("heart", size=22, color="var(--red-9)",
+                    style={"fill": "var(--red-9)"}),
+            rx.icon("heart", size=22, color="var(--gray-8)"),
+        ),
+        on_click=AuthState.toggle_drep_favorite(DrepDetailState.display_drep_id),
+        cursor="pointer",
+        padding="6px",
+        flex_shrink="0",
+        style={"display": "flex", "alignItems": "center"},
+    )
+
+
 def _profile_card() -> rx.Component:
     avatar = rx.cond(
         DrepDetailState.image_url != "",
@@ -464,7 +512,11 @@ def _profile_card() -> rx.Component:
                 rx.hstack(
                     rx.hstack(name_text, status_badge, spacing="3", align="center", wrap="wrap"),
                     rx.spacer(),
-                    drep_delegate_button(DrepDetailState.display_drep_id),
+                    rx.hstack(
+                        _drep_share_btn(),
+                        _drep_fav_btn(),
+                        spacing="1", align="center", flex_shrink="0",
+                    ),
                     spacing="3", align="center", width="100%", wrap="wrap",
                 ),
                 drep_id_block,
@@ -489,6 +541,12 @@ def _profile_card() -> rx.Component:
                         spacing="0", align="start",
                     ),
                     spacing="6", wrap="wrap",
+                ),
+                # 委任ボタン (右下)
+                rx.hstack(
+                    rx.spacer(),
+                    drep_delegate_button(DrepDetailState.display_drep_id),
+                    width="100%", align="center", padding_top="4px",
                 ),
                 spacing="3",
                 align_items="start",

--- a/cardanoism/pages/mypage.py
+++ b/cardanoism/pages/mypage.py
@@ -165,6 +165,20 @@ def _fav_pagination(page_var, total_var, prev_handler, next_handler) -> rx.Compo
     )
 
 
+def _export_csv_button(handler, disabled=False) -> rx.Component:
+    """CSV エクスポートボタン (各お気に入りタブ上部)。"""
+    return rx.button(
+        rx.icon("download", size=14),
+        rx.text(AuthState.t["favorites_export_csv"], size="2"),
+        variant="soft",
+        color_scheme="gray",
+        size="2",
+        cursor="pointer",
+        on_click=handler,
+        disabled=disabled,
+    )
+
+
 def _catalyst_list() -> rx.Component:
     return rx.vstack(
         rx.hstack(
@@ -202,8 +216,15 @@ def _catalyst_list() -> rx.Component:
                 value=AuthState.favorites_sort,
                 on_change=AuthState.set_favorites_sort,
             ),
+            rx.spacer(),
+            _export_csv_button(
+                AuthState.export_catalyst_favorites_csv,
+                disabled=AuthState.is_favorites_empty,
+            ),
             wrap="wrap",
             spacing="2",
+            width="100%",
+            align="center",
         ),
         rx.cond(
             AuthState.is_favorites_empty,
@@ -234,28 +255,39 @@ def _catalyst_list() -> rx.Component:
 
 
 def _governance_list() -> rx.Component:
-    return rx.cond(
-        AuthState.is_ga_favorites_empty,
-        rx.center(
+    return rx.vstack(
+        rx.hstack(
+            rx.spacer(),
+            _export_csv_button(
+                AuthState.export_governance_favorites_csv,
+                disabled=AuthState.is_ga_favorites_empty,
+            ),
+            width="100%", align="center",
+        ),
+        rx.cond(
+            AuthState.is_ga_favorites_empty,
+            rx.center(
+                rx.vstack(
+                    rx.icon("bookmark", size=36, color="var(--gray-6)"),
+                    rx.text("ガバナンスのお気に入りはまだありません", size="4", color="var(--gray-8)"),
+                    spacing="3",
+                    align="center",
+                ),
+                padding_y="40px",
+            ),
             rx.vstack(
-                rx.icon("bookmark", size=36, color="var(--gray-6)"),
-                rx.text("ガバナンスのお気に入りはまだありません", size="4", color="var(--gray-8)"),
-                spacing="3",
-                align="center",
+                rx.foreach(AuthState.filtered_ga_favorites, ga_favorite_card),
+                _fav_pagination(
+                    AuthState.ga_favorites_page,
+                    AuthState.ga_favorites_total_pages,
+                    AuthState.ga_favorites_prev_page,
+                    AuthState.ga_favorites_next_page,
+                ),
+                spacing="2",
+                width="100%",
             ),
-            padding_y="40px",
         ),
-        rx.vstack(
-            rx.foreach(AuthState.filtered_ga_favorites, ga_favorite_card),
-            _fav_pagination(
-                AuthState.ga_favorites_page,
-                AuthState.ga_favorites_total_pages,
-                AuthState.ga_favorites_prev_page,
-                AuthState.ga_favorites_next_page,
-            ),
-            spacing="2",
-            width="100%",
-        ),
+        spacing="3", width="100%",
     )
 
 
@@ -381,54 +413,76 @@ def pool_favorite_card(fav: rx.Var[dict]) -> rx.Component:
 
 
 def _drep_list() -> rx.Component:
-    return rx.cond(
-        AuthState.is_drep_favorites_empty,
-        rx.center(
+    return rx.vstack(
+        rx.hstack(
+            rx.spacer(),
+            _export_csv_button(
+                AuthState.export_drep_favorites_csv,
+                disabled=AuthState.is_drep_favorites_empty,
+            ),
+            width="100%", align="center",
+        ),
+        rx.cond(
+            AuthState.is_drep_favorites_empty,
+            rx.center(
+                rx.vstack(
+                    rx.icon("bookmark", size=36, color="var(--gray-6)"),
+                    rx.text(AuthState.t["favorites_drep_empty"], size="4", color="var(--gray-8)"),
+                    spacing="3",
+                    align="center",
+                ),
+                padding_y="40px",
+            ),
             rx.vstack(
-                rx.icon("bookmark", size=36, color="var(--gray-6)"),
-                rx.text(AuthState.t["favorites_drep_empty"], size="4", color="var(--gray-8)"),
-                spacing="3",
-                align="center",
+                rx.foreach(AuthState.filtered_drep_favorites, drep_favorite_card),
+                _fav_pagination(
+                    AuthState.drep_favorites_page,
+                    AuthState.drep_favorites_total_pages,
+                    AuthState.drep_favorites_prev_page,
+                    AuthState.drep_favorites_next_page,
+                ),
+                spacing="2",
+                width="100%",
             ),
-            padding_y="40px",
         ),
-        rx.vstack(
-            rx.foreach(AuthState.filtered_drep_favorites, drep_favorite_card),
-            _fav_pagination(
-                AuthState.drep_favorites_page,
-                AuthState.drep_favorites_total_pages,
-                AuthState.drep_favorites_prev_page,
-                AuthState.drep_favorites_next_page,
-            ),
-            spacing="2",
-            width="100%",
-        ),
+        spacing="3", width="100%",
     )
 
 
 def _pool_list() -> rx.Component:
-    return rx.cond(
-        AuthState.is_pool_favorites_empty,
-        rx.center(
+    return rx.vstack(
+        rx.hstack(
+            rx.spacer(),
+            _export_csv_button(
+                AuthState.export_pool_favorites_csv,
+                disabled=AuthState.is_pool_favorites_empty,
+            ),
+            width="100%", align="center",
+        ),
+        rx.cond(
+            AuthState.is_pool_favorites_empty,
+            rx.center(
+                rx.vstack(
+                    rx.icon("bookmark", size=36, color="var(--gray-6)"),
+                    rx.text(AuthState.t["favorites_pool_empty"], size="4", color="var(--gray-8)"),
+                    spacing="3",
+                    align="center",
+                ),
+                padding_y="40px",
+            ),
             rx.vstack(
-                rx.icon("bookmark", size=36, color="var(--gray-6)"),
-                rx.text(AuthState.t["favorites_pool_empty"], size="4", color="var(--gray-8)"),
-                spacing="3",
-                align="center",
+                rx.foreach(AuthState.filtered_pool_favorites, pool_favorite_card),
+                _fav_pagination(
+                    AuthState.pool_favorites_page,
+                    AuthState.pool_favorites_total_pages,
+                    AuthState.pool_favorites_prev_page,
+                    AuthState.pool_favorites_next_page,
+                ),
+                spacing="2",
+                width="100%",
             ),
-            padding_y="40px",
         ),
-        rx.vstack(
-            rx.foreach(AuthState.filtered_pool_favorites, pool_favorite_card),
-            _fav_pagination(
-                AuthState.pool_favorites_page,
-                AuthState.pool_favorites_total_pages,
-                AuthState.pool_favorites_prev_page,
-                AuthState.pool_favorites_next_page,
-            ),
-            spacing="2",
-            width="100%",
-        ),
+        spacing="3", width="100%",
     )
 
 

--- a/cardanoism/pages/staking_pool_detail.py
+++ b/cardanoism/pages/staking_pool_detail.py
@@ -170,34 +170,56 @@ def _breadcrumb() -> rx.Component:
 
 
 def _pool_share_btn() -> rx.Component:
-    """Pool ページの URL をクリップボードへコピーするシェアボタン。"""
-    pid = PoolDetailState.pool["pool_id"]
-    return rx.el.button(
-        rx.icon("share-2", size=18, color="var(--gray-11)"),
-        on_click=[
-            rx.set_clipboard("https://cardanoism.com/staking/pool/" + pid),
-            rx.toast(
-                AuthState.t["pool_url_copied"],
-                position="top-center",
-                style={
-                    "background-color": "var(--indigo-11)",
-                    "color": "white",
-                    "border-radius": "0.5rem",
-                },
+    """Pool ページのシェアメニュー (X / LINE / URL コピー)。
+    ガバナンス提案モーダルのシェアボタンと同じ挙動。"""
+    return rx.menu.root(
+        rx.menu.trigger(
+            rx.icon(
+                "share-2", size=22, color="var(--gray-11)",
+                cursor="pointer", padding="4px",
             ),
-        ],
-        cursor="pointer",
-        style={
-            "display":       "inline-flex",
-            "alignItems":    "center",
-            "border":        "none",
-            "background":    "transparent",
-            "padding":       "6px",
-            "borderRadius":  "8px",
-            "transition":    "background 0.15s",
-            "flexShrink":    "0",
-        },
-        _hover={"background": "var(--gray-3)"},
+        ),
+        rx.menu.content(
+            rx.menu.item(
+                "X (Twitter)",
+                on_click=rx.call_script(
+                    "const t = document.querySelector('.pool-title')?.innerText ?? '';"
+                    "const url = 'https://x.com/intent/tweet'"
+                    "  + '?text=' + encodeURIComponent(t)"
+                    "  + '&url=' + encodeURIComponent(window.location.href);"
+                    "window.open(url,'x-share',"
+                    "'width=550,height=420,menubar=no,toolbar=no,"
+                    "location=no,status=no,resizable=yes,scrollbars=yes');"
+                ),
+            ),
+            rx.menu.item(
+                "LINE",
+                on_click=rx.call_script(
+                    "const t = document.querySelector('.pool-title')?.innerText ?? '';"
+                    "const url = 'https://social-plugins.line.me/lineit/share'"
+                    "  + '?url=' + encodeURIComponent(window.location.href)"
+                    "  + '&text=' + encodeURIComponent(t);"
+                    "window.open(url,'line-share',"
+                    "'width=520,height=520,menubar=no,toolbar=no,"
+                    "location=no,status=no,resizable=yes,scrollbars=yes');"
+                ),
+            ),
+            rx.menu.item(
+                AuthState.t["proposal_copy_url"],
+                on_click=[
+                    rx.call_script("navigator.clipboard.writeText(window.location.href);"),
+                    rx.toast(
+                        AuthState.t["pool_url_copied"],
+                        position="top-center",
+                        style={
+                            "background-color": "var(--indigo-11)",
+                            "color": "white",
+                            "border-radius": "0.5rem",
+                        },
+                    ),
+                ],
+            ),
+        ),
     )
 
 
@@ -247,8 +269,10 @@ def _header() -> rx.Component:
         ),
         rx.cond(
             p["pool_name"] != "",
-            rx.heading(p["pool_name"], size="6", weight="bold", color="var(--gray-12)"),
-            rx.heading(AuthState.t["staking_no_name"], size="6", weight="bold", color="var(--gray-10)"),
+            rx.heading(p["pool_name"], size="6", weight="bold",
+                       color="var(--gray-12)", class_name="pool-title"),
+            rx.heading(AuthState.t["staking_no_name"], size="6", weight="bold",
+                       color="var(--gray-10)", class_name="pool-title"),
         ),
         rx.cond(
             p["is_retiring"] != "",

--- a/cardanoism/pages/staking_pool_detail.py
+++ b/cardanoism/pages/staking_pool_detail.py
@@ -175,7 +175,7 @@ def _pool_share_btn() -> rx.Component:
     return rx.menu.root(
         rx.menu.trigger(
             rx.icon(
-                "share-2", size=22, color="var(--gray-11)",
+                "share-2", size=26, color="var(--gray-11)",
                 cursor="pointer", padding="4px",
             ),
         ),

--- a/cardanoism/pages/staking_pool_detail.py
+++ b/cardanoism/pages/staking_pool_detail.py
@@ -169,6 +169,56 @@ def _breadcrumb() -> rx.Component:
     )
 
 
+def _pool_share_btn() -> rx.Component:
+    """Pool ページの URL をクリップボードへコピーするシェアボタン。"""
+    pid = PoolDetailState.pool["pool_id"]
+    return rx.el.button(
+        rx.icon("share-2", size=18, color="var(--gray-11)"),
+        on_click=[
+            rx.set_clipboard("https://cardanoism.com/staking/pool/" + pid),
+            rx.toast(
+                AuthState.t["pool_url_copied"],
+                position="top-center",
+                style={
+                    "background-color": "var(--indigo-11)",
+                    "color": "white",
+                    "border-radius": "0.5rem",
+                },
+            ),
+        ],
+        cursor="pointer",
+        style={
+            "display":       "inline-flex",
+            "alignItems":    "center",
+            "border":        "none",
+            "background":    "transparent",
+            "padding":       "6px",
+            "borderRadius":  "8px",
+            "transition":    "background 0.15s",
+            "flexShrink":    "0",
+        },
+        _hover={"background": "var(--gray-3)"},
+    )
+
+
+def _pool_fav_btn() -> rx.Component:
+    """Pool お気に入り (ハート) トグルボタン。"""
+    pid = PoolDetailState.pool["pool_id"]
+    return rx.box(
+        rx.cond(
+            AuthState.pool_favorite_ids.contains(pid),
+            rx.icon("heart", size=22, color="var(--red-9)",
+                    style={"fill": "var(--red-9)"}),
+            rx.icon("heart", size=22, color="var(--gray-8)"),
+        ),
+        on_click=AuthState.toggle_pool_favorite(pid),
+        cursor="pointer",
+        padding="6px",
+        flex_shrink="0",
+        style={"display": "flex", "alignItems": "center"},
+    )
+
+
 def _header() -> rx.Component:
     p = PoolDetailState.pool
     icon = rx.cond(
@@ -272,11 +322,21 @@ def _header() -> rx.Component:
                     pool_id_row,
                     spacing="2", align_items="start", flex="1", min_width="0",
                 ),
-                # 委任 CTA はボックス右上に配置
-                _delegate_cta(),
+                # 右上: シェア + お気に入り
+                rx.hstack(
+                    _pool_share_btn(),
+                    _pool_fav_btn(),
+                    spacing="1", align="center", flex_shrink="0",
+                ),
                 spacing="4", align="start", width="100%", wrap="wrap",
             ),
             about,
+            # 右下: 委任 CTA
+            rx.hstack(
+                rx.spacer(),
+                _delegate_cta(),
+                width="100%", align="center", padding_top="4px",
+            ),
             spacing="4", align_items="stretch", width="100%",
         ),
         padding="20px 22px",


### PR DESCRIPTION
## Summary

3 系統の改善をまとめてリリース: Koios 429 の根治、詳細ページの UI 統一、お気に入りの CSV エクスポート。

### 1. Koios 429 対策 (2 コミット)

- **`a984dd4` cron jitter**: 毎時 0 分に最大 8 個並列起動 → 1〜14 分内で分散して同時起動を最大 2 個に
- **`2173b5c` drep_sync D+B ハイブリッド**: 1 起動 ~1840 reqs × 96 回/日 = 176k reqs/日 (50k 制限の 3.5 倍) を ~11.5k/日 (93% 削減) に
  - D: `/drep_info.amount` (epoch-boundary) を全 active DRep に反映
  - B: `drep_dirty_marker` テーブル新設、listener が vote_delegation で記録 → dirty DRep だけ `/drep_delegators` で live 集計
  - `--full` フラグで全件モード (日次 fallback)

### 2. DRep / Pool 詳細ページ UI (3 コミット)

- **`325a44d`**: 右上に share + heart、右下に委任ボタンへ再配置
- **`785c98d`**: シェアボタンをガバナンス提案モーダルと同じドロップダウンに統一 (X / LINE / URL コピー)
- **`e344e75`**: シェアボタンを 1 サイズ拡大 (22 → 26)

### 3. お気に入り CSV エクスポート (3 コミット)

- **`04a2ccd`**: 4 タブ (catalyst / governance / drep / pool) 上部に CSV エクスポートボタン追加、UTF-8 BOM 付き、英語キー
- **`39217ab` / `b6875f1`**: governance エクスポートの不具合修正
  - collation 不一致を解消
  - `withdrawal_ada` を `governance_actions.withdrawal_total_lovelace` から取得するように修正 (旧: `ga_withdrawal_payout` SUM = ratified 後しか入らない)