### PR TITLE
 DB プール耐障害性 + Koios レート対策 + お気に入りCSV/UI 改善

### DIFF
--- a/cardanoism/backend/dashboard_state.py
+++ b/cardanoism/backend/dashboard_state.py
@@ -30,6 +30,7 @@ from cardanoism.backend.drep_db import get_drep
 from cardanoism.backend.vote_db import get_votes_by_drep
 from cardanoism.backend.stake_rewards_db import (
     get_recent_rewards,
+    get_rewards_for_epochs,
     get_total_rewards,
     get_total_rewards_by_type,
     has_rewards_for_addresses,
@@ -703,7 +704,16 @@ class DashboardState(rx.State):
             self.rewards_missing_addresses = []
             return
 
-        rows = get_recent_rewards(addrs, n_epochs=RECENT_REWARDS_EPOCHS)
+        # 「直近 N エポック」ラベル通り、現在エポックから連続した N 個を target に。
+        # stake_rewards テーブルに行が無いエポックは 0 ADA で補完する。
+        from cardanoism.backend.koios import get_current_epoch
+        current_epoch = get_current_epoch() or 0
+        target_epochs = [
+            current_epoch - i
+            for i in range(RECENT_REWARDS_EPOCHS)
+            if current_epoch - i >= 0
+        ]
+        rows = get_rewards_for_epochs(addrs, target_epochs)
         # rows 1 行 = (stake, epoch, type) なので epoch ごとに type 別に集約する
         # by_addr_by_epoch[addr][epoch] = {"member": N, "leader": N, "other": N}
         by_addr_by_epoch: dict[str, dict[int, dict[str, int]]] = {}
@@ -726,10 +736,10 @@ class DashboardState(rx.State):
         for sa in addrs:
             epoch_map = by_addr_by_epoch.get(sa, {})
             items: list[dict[str, str]] = []
-            # get_recent_rewards の LIMIT は行数ベースで余分に取れることがあるため、
-            # ここで各アドレスの直近 RECENT_REWARDS_EPOCHS エポックに明示的に絞る。
-            for ep in sorted(epoch_map.keys(), reverse=True)[:RECENT_REWARDS_EPOCHS]:
-                v = epoch_map[ep]
+            # target_epochs (現在エポックから N 個前まで) を新しい順に並べて 0 補完。
+            # epoch_map に該当 ep が無ければ全 type 0 として表示する。
+            for ep in target_epochs:
+                v = epoch_map.get(ep) or {"member": 0, "leader": 0, "other": 0}
                 total_lov = v["member"] + v["leader"] + v["other"]
                 items.append({
                     "epoch_no":   str(ep),

--- a/cardanoism/backend/db_connect.py
+++ b/cardanoism/backend/db_connect.py
@@ -78,8 +78,21 @@ def dbConnect():
     try:
         conn = pool.get_connection()
     except mariadb.Error as e:
-        print(f"Error getting connection from pool: {e}")
-        sys.exit(1)
+        logger.error("Error getting connection from pool: %s", e)
+        raise
+
+    try:
+        conn.ping()
+    except mariadb.Error:
+        try:
+            conn.reconnect()
+        except mariadb.Error as e:
+            logger.error("Failed to revive a dead pooled connection: %s", e)
+            try:
+                conn.close()
+            except mariadb.Error:
+                pass
+            raise
 
     #Get Cursor
     cursor = conn.cursor(dictionary=True)

--- a/cardanoism/backend/stake_rewards_db.py
+++ b/cardanoism/backend/stake_rewards_db.py
@@ -66,6 +66,10 @@ def get_recent_rewards(stake_addresses: list[str], n_epochs: int = 5) -> list[di
 
     戻り値: 1 行 = 1 (stake, epoch, type)。同じ epoch でも member / leader が別行で返る。
     epoch_no DESC, stake_address ASC, reward_type ASC でソート済み。
+
+    注: stake_rewards テーブルには「報酬を受け取った epoch」しか行が無いため、
+    報酬が飛び飛びのアドレスでは古い epoch が混ざる。
+    「直近 N エポックの連続値 (0 補完)」が必要なら get_rewards_for_epochs を使う。
     """
     if not stake_addresses:
         return []
@@ -83,6 +87,31 @@ def get_recent_rewards(stake_addresses: list[str], n_epochs: int = 5) -> list[di
             return [dict(row) for row in cursor.fetchall()]
     except Exception as e:  # noqa: BLE001
         logger.exception("get_recent_rewards failed: %s", e)
+        return []
+
+
+def get_rewards_for_epochs(stake_addresses: list[str], epochs: list[int]) -> list[dict]:
+    """指定アドレス × 指定 epoch のみの報酬行を返す。
+
+    戻り値: 1 行 = 1 (stake, epoch, type)。stake_rewards に行が存在する分だけ返る。
+    呼び出し側で 0 補完して連続エポック表示に整える。
+    """
+    if not stake_addresses or not epochs:
+        return []
+    addr_ph = ",".join(["?"] * len(stake_addresses))
+    ep_ph   = ",".join(["?"] * len(epochs))
+    sql = (
+        f"SELECT stake_address, epoch_no, amount_lovelace, pool_id, reward_type "
+        f"FROM stake_rewards "
+        f"WHERE stake_address IN ({addr_ph}) AND epoch_no IN ({ep_ph})"
+    )
+    params = list(stake_addresses) + [int(e) for e in epochs]
+    try:
+        with get_db() as (cursor, _):
+            cursor.execute(sql, params)
+            return [dict(row) for row in cursor.fetchall()]
+    except Exception as e:  # noqa: BLE001
+        logger.exception("get_rewards_for_epochs failed: %s", e)
         return []
 
 


### PR DESCRIPTION
## 主な変更
- fix(db): プール取得失敗で sys.exit せず例外送出 + 死んだ接続を ping/reconnect で蘇生（Granian ワーカー上の sys.exit がパニック→プール全断を誘発する不具合の引き金を除去）
- fix(favorites-export): governance CSV エクスポートの collation 不一致／withdrawal_ada ソース誤りを修正
- feat(mypage): お気に入り 4 タブに CSV エクスポート機能を追加
- fix(dashboard): 委任先プール報酬「直近5エポック」を連続5個 + 0補完で表示
- fix(drep-sync / cron): Koios 50k/day・429 対策（D+B ハイブリッド同期 + jitter）
- ui(drep/pool detail): share/heart/委任ボタンの再配置・ドロップダウン統一・サイズ調整